### PR TITLE
build: lock serde_with to 3.18.0 (MSRV-compatible with 1.94.0-nightly)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8233,12 +8233,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64 0.22.1",
- "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -8253,9 +8252,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
Fixes #5.

On a fresh clone + `cargo build --release --workspace`, build fails because Cargo.lock pins `serde_with = 3.20.0` but its MSRV expectations exceed Rust 1.94.0-nightly. `cargo update -p serde_with` resolves cleanly to 3.18.0; this PR captures the result.

Single-file change. Verified by running the full release workspace build to completion (~12min wall clock) and exercising `dregg-demo` + `dregg-node mcp` (handshake + tools/list returning the full 46-tool surface).

Tested:
- `rustc 1.94.0-nightly (8d670b93d 2025-12-31)` (the nightly that triggered the original failure)
- `cargo build --release --workspace` exit 0 after the lock update
- `dregg-demo` (federated authorization demo) ran end-to-end clean
- `dregg-node mcp` MCP handshake validates

Context: doing a polyana agent-team coordination evaluation per Discord chat with you. Will be filing more docs/discoverability suggestions as separate issues (already filed #1-#5; this PR closes #5).

Let me know if you'd prefer a different version, want CI MSRV-enforcement first, or want me to verify against a different rustc.