### PR TITLE
style: apply rustfmt baseline

### DIFF
--- a/cell/src/note.rs
+++ b/cell/src/note.rs
@@ -585,7 +585,12 @@ mod tests {
     #[cfg(feature = "zkvm")]
     #[test]
     fn poseidon2_commitment_deterministic() {
-        let n = Note::with_nonce(test_owner(7), [3, 250, 0, 0, 0, 0, 0, 0], [55u8; 32], [66u8; 32]);
+        let n = Note::with_nonce(
+            test_owner(7),
+            [3, 250, 0, 0, 0, 0, 0, 0],
+            [55u8; 32],
+            [66u8; 32],
+        );
         assert_eq!(n.poseidon2_commitment(), n.poseidon2_commitment());
     }
 

--- a/cell/src/value_commitment.rs
+++ b/cell/src/value_commitment.rs
@@ -841,7 +841,12 @@ pub fn prove_asset_conservation(
     excess_blinding: &Scalar,
     message: &[u8],
 ) -> ConservationProof {
-    prove_conservation(input_commitments, output_commitments, excess_blinding, message)
+    prove_conservation(
+        input_commitments,
+        output_commitments,
+        excess_blinding,
+        message,
+    )
 }
 
 /// Verify an asset-hiding conservation proof. See [`prove_asset_conservation`]
@@ -1069,7 +1074,10 @@ pub fn prove_asset_equality_with_message(
     }
 
     AssetEqualityProof {
-        nonce_commitments: nonce_points.iter().map(|t| t.compress().to_bytes()).collect(),
+        nonce_commitments: nonce_points
+            .iter()
+            .map(|t| t.compress().to_bytes())
+            .collect(),
         response_asset: s_at.to_bytes(),
         response_values,
         response_blindings,
@@ -1791,7 +1799,10 @@ mod tests {
         // because the asset term at*H_asset remains.
         let hidden_residual = c_asset_a.point - Scalar::from(value) * value_generator();
         assert_ne!(hidden_residual, r1 * randomness_generator());
-        assert_ne!(hidden_residual, r1 * randomness_generator() - randomness_generator());
+        assert_ne!(
+            hidden_residual,
+            r1 * randomness_generator() - randomness_generator()
+        );
     }
 
     #[test]
@@ -2069,13 +2080,7 @@ mod tests {
         let c2 = ValueCommitment::commit_hidden_asset(200, asset, &r2);
         let all = vec![c1, c2];
 
-        let proof = prove_asset_equality_with_message(
-            &all,
-            asset,
-            &[100, 200],
-            &[r1, r2],
-            b"tx-A",
-        );
+        let proof = prove_asset_equality_with_message(&all, asset, &[100, 200], &[r1, r2], b"tx-A");
         assert!(verify_asset_equality_with_message(&all, &proof, b"tx-A").is_ok());
         assert!(
             verify_asset_equality_with_message(&all, &proof, b"tx-B").is_err(),

--- a/circuit/src/note_spending_air.rs
+++ b/circuit/src/note_spending_air.rs
@@ -466,10 +466,26 @@ pub fn commitment_chain(
     let mut idx = 5usize;
     for step in 0..limb_col::CHAIN_INTERMEDIATES {
         intermediates[step] = running;
-        let t0 = if idx < limbs.len() { limbs[idx] } else { BabyBear::ZERO };
-        let t1 = if idx + 1 < limbs.len() { limbs[idx + 1] } else { BabyBear::ZERO };
-        let t2 = if idx + 2 < limbs.len() { limbs[idx + 2] } else { BabyBear::ZERO };
-        let t3 = if idx + 3 < limbs.len() { limbs[idx + 3] } else { BabyBear::ZERO };
+        let t0 = if idx < limbs.len() {
+            limbs[idx]
+        } else {
+            BabyBear::ZERO
+        };
+        let t1 = if idx + 1 < limbs.len() {
+            limbs[idx + 1]
+        } else {
+            BabyBear::ZERO
+        };
+        let t2 = if idx + 2 < limbs.len() {
+            limbs[idx + 2]
+        } else {
+            BabyBear::ZERO
+        };
+        let t3 = if idx + 3 < limbs.len() {
+            limbs[idx + 3]
+        } else {
+            BabyBear::ZERO
+        };
         running = hash_fact(running, &[t0, t1, t2, t3]);
         idx += 4;
     }
@@ -580,13 +596,8 @@ impl NoteSpendingWitness {
         // (high limbs zero); value/asset_type split into low/high. Callers with
         // raw 32-byte/u64 note fields should use `from_note_limbs` for true
         // full-256-bit binding.
-        let preimage_limbs = Self::limbs_from_felts(
-            owner,
-            value,
-            asset_type,
-            creation_nonce,
-            randomness,
-        );
+        let preimage_limbs =
+            Self::limbs_from_felts(owner, value, asset_type, creation_nonce, randomness);
         Self {
             owner,
             value,
@@ -1126,13 +1137,8 @@ pub fn create_test_witness(
         merkle_positions.push(pos);
     }
 
-    let preimage_limbs = NoteSpendingWitness::limbs_from_felts(
-        owner,
-        value,
-        asset_type,
-        creation_nonce,
-        randomness,
-    );
+    let preimage_limbs =
+        NoteSpendingWitness::limbs_from_felts(owner, value, asset_type, creation_nonce, randomness);
     NoteSpendingWitness {
         owner,
         value,

--- a/sdk/src/privacy.rs
+++ b/sdk/src/privacy.rs
@@ -976,7 +976,10 @@ mod tests {
             );
 
         // The published nullifier matches the note's intrinsic nullifier.
-        assert_eq!(transfer.nullifier, secret.note.nullifier(&secret.spending_key));
+        assert_eq!(
+            transfer.nullifier,
+            secret.note.nullifier(&secret.spending_key)
+        );
         // The output note carries the same value/asset as the spent input.
         assert_eq!(transfer.recipient_secret.note.value(), secret.note.value());
         assert_eq!(


### PR DESCRIPTION
## Summary

- Applies `cargo fmt --all` to the current baseline so the Format CI check has a small, isolated PR.
- Touches only rustfmt-driven whitespace/line wrapping in four Rust files.

## Verification

- `cargo fmt --all -- --check` passes.
- `git diff --check` passes.

## Scope boundary

This is one formatting-only split-out from the broader workspace cleanup rail. It intentionally does not include audit config, no-unchecked-auth guard changes, clippy fixes, or preflight/test repairs.
