### PR TITLE
fix: avoid CLI update version flag conflict

### DIFF
--- a/cli/src/commands/directory.rs
+++ b/cli/src/commands/directory.rs
@@ -53,9 +53,9 @@ pub enum DirectoryCommand {
         /// New URI to set.
         new_uri: String,
 
-        /// Expected current version (for CAS). If omitted, fetches current.
-        #[arg(long)]
-        version: Option<u64>,
+        /// Expected current directory-entry version (for CAS). If omitted, fetches current.
+        #[arg(long = "expected-version")]
+        expected_version: Option<u64>,
     },
 
     /// Create a new sub-directory.
@@ -101,8 +101,8 @@ pub async fn run(
         DirectoryCommand::Update {
             path,
             new_uri,
-            version,
-        } => update(cfg, ctx, &path, &new_uri, version).await,
+            expected_version,
+        } => update(cfg, ctx, &path, &new_uri, expected_version).await,
         DirectoryCommand::Create { path } => create(cfg, ctx, &path).await,
         DirectoryCommand::Discover { tag, kind } => discover(cfg, ctx, &tag, kind).await,
         DirectoryCommand::Tree { path } => tree(cfg, ctx, &path).await,


### PR DESCRIPTION
## Summary

- Fixes the CLI completions panic caused by the `directory update` CAS argument using Clap's reserved/global `version` argument name.
- Renames the generated CLI flag to `--expected-version` and the derive field to `expected_version`, avoiding conflict with Clap's auto-generated `--version` flag while preserving the CAS meaning.

## Verification

- `cargo fmt -p dregg-cli -- --check` passes.
- `git diff --check` passes.
- `cargo run -p dregg-cli -- completions zsh` succeeds and emits completions.
- `cargo run -p dregg-cli -- version` succeeds and prints version output.

## Scope boundary

This is one CLI-specific split-out from the broader workspace cleanup rail. It intentionally does not include formatting baseline, audit config, no-unchecked-auth guard changes, clippy fixes, or preflight/demo-agent repairs.
