### PR TITLE
fix(node): recover torn commit-log tail on boot instead of refusing

### DIFF
--- a/node/src/state.rs
+++ b/node/src/state.rs
@@ -630,6 +630,28 @@ impl NodeState {
         let db_path = data_dir.join("dregg.redb");
         let store =
             PersistentStore::open(&db_path).map_err(|e| format!("failed to open store: {e}"))?;
+        // Boot crash-recovery: a torn/poisoned commit-log tail (e.g. a process
+        // killed between the input-turn config write and the commit-record txn, or
+        // an unclean power-cycle) leaves the log's head inconsistent with its
+        // durably-recorded finalized root, so the convergence check below would
+        // REFUSE the whole image and strand the node (observed 2026-06-29 after a
+        // homelab PSU swap). Truncate any divergent tail to the last commit ordinal
+        // whose reconstructed root matches; peers backfill the dropped turn(s) via
+        // normal blocklace sync. No-op (returns 0) when already consistent; a
+        // genuinely divergent image with NO matching prefix still Errs (fail-closed
+        // on tampering). Uses the existing `PersistentStore::recover_to_last_consistent`
+        // (persist/src/commit_log.rs); mirrors starbridge `World::open_recovering`.
+        match store.recover_to_last_consistent() {
+            Ok(0) => {}
+            Ok(n) => tracing::warn!(
+                truncated = n,
+                "boot recovery: truncated {n} divergent commit-log record(s) to the \
+                 last-consistent ordinal (torn-tail crash recovery); peers will backfill"
+            ),
+            Err(e) => {
+                return Err(format!("boot recovery (recover_to_last_consistent) failed: {e}"));
+            }
+        }
 
         // Resolve key file path: absolute paths are used as-is,
         // relative paths are resolved from the data directory.
@@ -908,6 +930,28 @@ impl NodeState {
         let db_path = data_dir.join("dregg.redb");
         let store =
             PersistentStore::open(&db_path).map_err(|e| format!("failed to open store: {e}"))?;
+        // Boot crash-recovery: a torn/poisoned commit-log tail (e.g. a process
+        // killed between the input-turn config write and the commit-record txn, or
+        // an unclean power-cycle) leaves the log's head inconsistent with its
+        // durably-recorded finalized root, so the convergence check below would
+        // REFUSE the whole image and strand the node (observed 2026-06-29 after a
+        // homelab PSU swap). Truncate any divergent tail to the last commit ordinal
+        // whose reconstructed root matches; peers backfill the dropped turn(s) via
+        // normal blocklace sync. No-op (returns 0) when already consistent; a
+        // genuinely divergent image with NO matching prefix still Errs (fail-closed
+        // on tampering). Uses the existing `PersistentStore::recover_to_last_consistent`
+        // (persist/src/commit_log.rs); mirrors starbridge `World::open_recovering`.
+        match store.recover_to_last_consistent() {
+            Ok(0) => {}
+            Ok(n) => tracing::warn!(
+                truncated = n,
+                "boot recovery: truncated {n} divergent commit-log record(s) to the \
+                 last-consistent ordinal (torn-tail crash recovery); peers will backfill"
+            ),
+            Err(e) => {
+                return Err(format!("boot recovery (recover_to_last_consistent) failed: {e}"));
+            }
+        }
 
         let cclerk = AgentCipherclerk::from_key_bytes(zeroize::Zeroizing::new(key_bytes));
         let (witnessed_receipts, witnessed_receipt_order) = load_witnessed_receipts(&store);


### PR DESCRIPTION
## Real-world finding (homelab PSU swap, 2026-06-29)

A homelab box hosting a dregg devnet was power-cycled (graceful `docker stop -t 30`, then power-off for a PSU swap). On restart **all nodes crash-looped**:

```
ERROR dregg_node::state: reconstructed ledger root does NOT match the durably
recorded finalized root — STORE INTEGRITY EVENT, refusing to start
  recovered_root=9cdc20d2…  expected_root=8e91e943…
ERROR dregg_node: recovery convergence failed … refusing to serve a divergent ledger
```

The unclean stop left a **torn commit-log tail** (the head inconsistent with the durably-recorded finalized root). When all peers restart together (single-host devnet / whole-cluster power event) there is no healthy peer to resync from, so the net wedges with no recovery path.

## Root cause

The recovery primitive **already exists and is tested**: `PersistentStore::recover_to_last_consistent()` (`persist/src/commit_log.rs:1064`) — crash-safe, atomic, idempotent; truncates the divergent tail to the last commit ordinal whose reconstructed root matches. Its own doc-comment names this exact failure ("a process killed between the input-turn config write and the commit-record txn … refuses the whole image … STRANDS the owner. Recovery is the right answer, not refusal."). It's wired into the starbridge path via `World::open_recovering` (`starbridge-v2/src/world.rs:392`, used by `session.rs:1034`).

**But the consensus node boot doesn't use it.** `node/src/state.rs` (both `new_with_key_file` paths) reconstructs `checkpoint ⊕ store.cell_overlay_since(...)`, compares to `store.recovered_ledger_root()`, and hard-refuses on mismatch — on the *same* `PersistentStore` that exposes `recover_to_last_consistent()`.

## Fix

Call `store.recover_to_last_consistent()` right after each `PersistentStore::open` (before the overlay reconstruction). No-op (returns 0) when already consistent; truncates a torn tail otherwise; Errs only when **no** prefix matches = real divergence/tampering (fail-closed preserved). Dropped turns backfill via normal blocklace sync. Mirrors the already-shipped `open_recovering`.

## Open questions for review (your consensus core — marked DRAFT)

1. Is `recover_to_last_consistent()` safe at this boot point (right after open, before the rest of node state loads)?
2. Does dropping the torn tail need an **explicit** peer-resync trigger, or does normal blocklace sync backfill the dropped turn(s)?
3. Should the truncation count surface anywhere beyond the `tracing::warn!`?

Full write-up: `DreggNet/docs/RESTART-RECOVERY-FINDINGS-2026-06-29.md`. Build-verifying off-box; will mark ready when green.

— filed by the akapug/homelab side per the dreggnet collaboration.
