### PR TITLE
status: never report a lean producer that is not linked

### DIFF
--- a/node/src/state.rs
+++ b/node/src/state.rs
@@ -49,6 +49,44 @@ pub fn lean_producer_env_enabled() -> bool {
     )
 }
 
+/// The EFFECTIVE lean-producer setting for a freshly constructed node state: the
+/// operator's env intent (`lean_producer_env_enabled`) AND the build-time fact that
+/// the verified Lean executor archive is actually linked
+/// (`dregg_lean_ffi::lean_available`).
+///
+/// A marshal-only binary (no `libdregg_lean.a`) cannot run the verified producer no
+/// matter what the env says — and `lean_producer_enabled` is the field every
+/// reporting surface reads (`/status` `state_producer`/`lean_producer`, doctor,
+/// MCP). Leaving it `true` on a marshal-only build makes those surfaces present an
+/// UN-verified node as verified — the exact "serve as if verified" failure the
+/// marshal-only startup tripwire in `main.rs` exists to prevent, surviving on the
+/// API surface after the tripwire was bypassed with
+/// `DREGG_ALLOW_UNVERIFIED_CONSENSUS=1`.
+pub fn lean_producer_effective(env_enabled: bool, lean_linked: bool) -> bool {
+    env_enabled && lean_linked
+}
+
+#[cfg(test)]
+mod lean_producer_effective_tests {
+    use super::lean_producer_effective;
+
+    /// A marshal-only build must never report the lean producer, regardless of
+    /// env intent — `/status` would otherwise present an un-verified node as
+    /// verified.
+    #[test]
+    fn marshal_only_build_never_reports_lean_producer() {
+        assert!(!lean_producer_effective(true, false));
+        assert!(!lean_producer_effective(false, false));
+    }
+
+    /// A lean-linked build honors the operator's env opt-out.
+    #[test]
+    fn linked_build_respects_env_intent() {
+        assert!(lean_producer_effective(true, true));
+        assert!(!lean_producer_effective(false, true));
+    }
+}
+
 /// MCP per-tool capability enforcement opt-in (`DREGG_MCP_CAP_ENFORCE=1`).
 ///
 /// When enabled, the MCP `tools/call` surface REQUIRES every call to present an
@@ -222,7 +260,9 @@ pub struct NodeStateInner {
     /// post-state root is compared against the Lean-produced root; a divergence is logged loudly as
     /// a real soundness finding). Default `true` — THE SWAP: the verified Lean executor produces the
     /// committed state by default for the swap-safe COVERED set. Opt OUT via `DREGG_LEAN_PRODUCER=0`
-    /// (read at state construction) or by clearing this field. A turn touching a characterized
+    /// (read at state construction) or by clearing this field. On a marshal-only binary (no linked
+    /// `libdregg_lean.a`) this is FORCED `false` at construction (`lean_producer_effective`) so
+    /// `/status` and every other reporting surface never present an un-verified node as verified. A turn touching a characterized
     /// root-gap effect (root provably diverges) or an unmappable effect falls back to the Rust
     /// producer for that turn, with a logged reason — never a silent commit of divergent state.
     pub lean_producer_enabled: bool,
@@ -840,7 +880,10 @@ impl NodeState {
                 checkpoint_interval: dregg_federation::DEFAULT_CHECKPOINT_INTERVAL,
                 prove_transitions: false,
                 full_turn_proving_enabled: false,
-                lean_producer_enabled: lean_producer_env_enabled(),
+                lean_producer_enabled: lean_producer_effective(
+                    lean_producer_env_enabled(),
+                    dregg_lean_ffi::lean_available(),
+                ),
                 fee_well: None,
                 issuer_wells: Vec::new(),
                 mcp_cap_enforce: mcp_cap_enforce_env_enabled(),
@@ -1000,7 +1043,10 @@ impl NodeState {
                 checkpoint_interval: dregg_federation::DEFAULT_CHECKPOINT_INTERVAL,
                 prove_transitions: false,
                 full_turn_proving_enabled: false,
-                lean_producer_enabled: lean_producer_env_enabled(),
+                lean_producer_enabled: lean_producer_effective(
+                    lean_producer_env_enabled(),
+                    dregg_lean_ffi::lean_available(),
+                ),
                 fee_well: None,
                 issuer_wells: Vec::new(),
                 mcp_cap_enforce: mcp_cap_enforce_env_enabled(),


### PR DESCRIPTION
## The bug

`lean_producer_enabled` is initialized purely from the `DREGG_LEAN_PRODUCER` env intent (an opt-out, so it defaults **on**) and never consults `dregg_lean_ffi::lean_available()`:

```rust
lean_producer_enabled: lean_producer_env_enabled(),
```

On a marshal-only binary started with `DREGG_ALLOW_UNVERIFIED_CONSENSUS=1`, the startup log correctly warns *"do not present this node as verified"* — but `/status` keeps reporting `state_producer:"lean"` / `lean_producer:true` to every API consumer. A monitoring or light-client consumer polling `/status` believes it is talking to a verified-Lean producer that the node itself logged it is not running. This is the API-surface half of the same invariant the fail-closed startup tripwire enforces at boot ("a node must never serve as if verified while running the un-verified executor") — the boot half got fixed, the status half survived.

## The fix

Gate the field at construction: env intent AND the linked-archive fact, via a pure helper mirroring the existing `marshal_only_must_refuse` pattern:

```rust
pub fn lean_producer_effective(env_enabled: bool, lean_linked: bool) -> bool {
    env_enabled && lean_linked
}
```

Both `NodeState` construction sites now use `lean_producer_effective(lean_producer_env_enabled(), dregg_lean_ffi::lean_available())`. Fixing the field (rather than the `/status` handler) fixes every reporting surface that reads it, and composes with the existing runtime demotion path — the starting value only ever becomes more conservative.

The helper is a pure function of two booleans because `lean_available()` is a build-time constant — a test asserting the combined result would flip between lean-linked and seedless build hosts. The truth table is tested directly (`marshal_only_build_never_reports_lean_producer`, `linked_build_respects_env_intent`).

## Verification

- Truth-table unit tests pass (`cargo test -p dregg-node --bin dregg-node lean_producer_effective`).
- Live: on a marshal-only build (clean clone, no Lean seed) run with the unverified opt-in, `/status` reported `"state_producer":"lean","lean_producer":true` before the patch and `"state_producer":"rust","lean_producer":false` after.

## How found

Self-hosted a solo node from a clean clone (WSL2/Ubuntu 24.04, commit 2d5bf085). No Lean seed release exists yet (`lean-seed.pin` has `TAG=` empty), so the build was marshal-only; the node correctly refused to start until the explicit opt-in was set — and then `/status` disagreed with the startup log.

## Provenance

This work was done agent-assisted: keeminlee working with a Claude agent (fable-jetto) that stood up the node, traced the field, and drafted the patch; the human reviewed and can answer for every line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
