### PR TITLE
quickstart: document the faucet public_key idiom; make demo/name failures fail loud

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -20,9 +20,11 @@ node's state producer IS the *verified Lean executor*. But that executor links a
   the slow way, `./scripts/bootstrap.sh` (compiles it from source, **hours** the
   first time because it builds mathlib).
 - **marshal-only** (`state_producer:"rust"`): a plain `cargo build` with **no
-  seed** silently builds this — the node runs the *un-verified* Rust executor. It
-  is fine for UI/dev, but it is **not** the verified node. Nothing errors; the
-  node just logs `MARSHAL-ONLY BUILD DETECTED` at startup.
+  seed** builds this — the node would run the *un-verified* Rust executor. It is
+  fine for UI/dev, but it is **not** the verified node. The node **refuses to
+  start** in this mode unless you explicitly opt in with
+  `DREGG_ALLOW_UNVERIFIED_CONSENSUS=1` — fail-closed: an unverified node is a
+  deliberate choice, never a silent default.
 
 The one-command path that does the right thing (fetch seed → build → run →
 report which mode you got) is **`./scripts/run-node-10min.sh`**. The sections
@@ -60,8 +62,12 @@ seed entirely:
 ```sh
 cargo build -p dregg-node
 ./target/debug/dregg-node init --data-dir /tmp/my-dregg
+DREGG_ALLOW_UNVERIFIED_CONSENSUS=1 \
 ./target/debug/dregg-node run  --data-dir /tmp/my-dregg --enable-faucet --port 8421 &
 ```
+
+(Without the env var, a seedless build refuses to start rather than silently
+serving the un-verified executor — see the note above.)
 
 ### Check it either way
 
@@ -78,7 +84,7 @@ curl -s http://localhost:8421/status
 `state_producer:"lean"` / `lean_producer:true` is the point: the node executes
 turns by calling the verified Lean function, not a Rust reimplementation. A
 marshal-only node instead reads `state_producer:"rust"` / `lean_producer:false`
-here (and logged `MARSHAL-ONLY BUILD DETECTED` on startup). (`full_turn_proving`
+here (and logged `MARSHAL-ONLY BUILD OVERRIDDEN` on startup). (`full_turn_proving`
 is off
 by default — the per-turn STARK is on the hot path; pass `--prove-turns` to turn
 it on, which is what an audit-grade node runs.)
@@ -173,10 +179,17 @@ export DREGG_API_TOKEN=$(curl -s -X POST http://localhost:8421/cipherclerk/unloc
 
 AGENT=$(curl -s http://localhost:8421/api/node/identity \
   | python3 -c 'import json,sys;print(json.load(sys.stdin)["agent_cell"])')
+NODE_PK=$(curl -s http://localhost:8421/api/node/identity \
+  | python3 -c 'import json,sys;print(json.load(sys.stdin)["public_key"])')
 
-# fund the operator cell so it can pay the turn's fee (skip if already funded):
+# fund the operator cell so it can pay the turn's fee (skip if already funded).
+# IMPORTANT: include public_key on the FIRST faucet call that touches this cell.
+# A faucet call without it materializes the cell with a ZERO public key, the
+# faucet never rewrites an existing cell's key, and every signed turn on this
+# data dir then fails with "Ed25519 signature verification failed" — including
+# the turn below and every step of `dregg demo` (§4).
 curl -s -X POST http://localhost:8421/api/faucet -H 'content-type: application/json' \
-  -d "{\"recipient\":\"$AGENT\",\"amount\":5000}" >/dev/null
+  -d "{\"recipient\":\"$AGENT\",\"amount\":5000,\"public_key\":\"$NODE_PK\"}" >/dev/null
 
 curl -s -X POST http://localhost:8421/api/turns/submit \
   -H "Authorization: Bearer $DREGG_API_TOKEN" -H 'content-type: application/json' \

--- a/cli/src/commands/name.rs
+++ b/cli/src/commands/name.rs
@@ -261,7 +261,14 @@ async fn submit_effects(
     Ok(data)
 }
 
-fn render_turn(ctx: &Context, data: &serde_json::Value, action: &str) {
+/// Render a submitted turn's outcome and return whether the node accepted it.
+///
+/// Callers must propagate a `false` as an `Err` — swallowing it made
+/// `dregg demo` print its success banner after every mutating step was
+/// rejected (and left the standalone `dregg name …` commands exiting 0 on
+/// rejection).
+#[must_use]
+fn render_turn(ctx: &Context, data: &serde_json::Value, action: &str) -> bool {
     let accepted = data["accepted"].as_bool().unwrap_or(false);
     let turn_hash = data["turn_hash"].as_str().unwrap_or("?");
     let proof_status = data["proof_status"].as_str().unwrap_or("unknown");
@@ -279,6 +286,12 @@ fn render_turn(ctx: &Context, data: &serde_json::Value, action: &str) {
         other => other,
     };
     ctx.kv("Proof", proof_line);
+    accepted
+}
+
+/// Turn a rejected submission into a hard error naming the failed action.
+fn rejected(action: &str) -> Box<dyn std::error::Error> {
+    format!("{action} was rejected by the node (see the error above)").into()
 }
 
 // ─── Commands ────────────────────────────────────────────────────────────────
@@ -325,12 +338,12 @@ async fn register(
         ctx.json_stdout(&data);
         return Ok(());
     }
-    render_turn(ctx, &data, "Registration");
-    if data["accepted"].as_bool().unwrap_or(false) {
-        ctx.info(&format!(
-            "  Resolve it:  dregg name resolve {name} --cell {target}"
-        ));
+    if !render_turn(ctx, &data, "Registration") {
+        return Err(rejected("Registration"));
     }
+    ctx.info(&format!(
+        "  Resolve it:  dregg name resolve {name} --cell {target}"
+    ));
     Ok(())
 }
 
@@ -445,7 +458,9 @@ async fn set_target(
     }
     ctx.header(&format!("Set target for '{name}'"));
     ctx.kv("Target URI", target_uri);
-    render_turn(ctx, &data, "Set-target");
+    if !render_turn(ctx, &data, "Set-target") {
+        return Err(rejected("Set-target"));
+    }
     Ok(())
 }
 
@@ -472,7 +487,9 @@ async fn renew(
     }
     ctx.header(&format!("Renew '{name}'"));
     ctx.kv("New expiry", &expiry.to_string());
-    render_turn(ctx, &data, "Renewal");
+    if !render_turn(ctx, &data, "Renewal") {
+        return Err(rejected("Renewal"));
+    }
     Ok(())
 }
 
@@ -502,7 +519,9 @@ async fn transfer(
         "New owner",
         &crate::output::abbrev_hex(&owner_hash_hex(new_owner), 8, 4),
     );
-    render_turn(ctx, &data, "Transfer");
+    if !render_turn(ctx, &data, "Transfer") {
+        return Err(rejected("Transfer"));
+    }
     Ok(())
 }
 
@@ -527,6 +546,8 @@ async fn revoke(
         return Ok(());
     }
     ctx.header(&format!("Revoke '{name}'"));
-    render_turn(ctx, &data, "Revocation");
+    if !render_turn(ctx, &data, "Revocation") {
+        return Err(rejected("Revocation"));
+    }
     Ok(())
 }


### PR DESCRIPTION
## The theme

A stranger following `QUICKSTART.md` on a fresh clone hits walls the docs built. Two code fixes and two doc fixes, one story.

## 1. `dregg demo` printed "OK: A full nameservice lifecycle ran end-to-end" after every step was rejected

The shared outcome renderer in `cli/src/commands/name.rs` printed the node's verdict but discarded it:

```rust
fn render_turn(ctx: &Context, data: &serde_json::Value, action: &str) { ... }  // no return value
```

so every mutating command ended `render_turn(...); Ok(())` — `dregg name register/transfer/revoke/renew/set-target` exited 0 on rejection, and `dregg demo` (which strings five of them together) sailed through rejections and printed its success banner.

`render_turn` now returns the verdict, marked `#[must_use]` so no future call site can silently drop it, and all five callers propagate rejection as a hard error:

```rust
if !render_turn(ctx, &data, "Transfer") {
    return Err(rejected("Transfer"));
}
```

Verified live: on a node whose operator cell has a zero key (the refused-first-launch state described in item 3), the demo now stops at the first rejection and exits 1 with no banner; on a healthy node it runs green end-to-end and exits 0. Standalone `dregg name` commands exit 1 on rejection.

## 2. QUICKSTART's "Verified vs marshal-only" text describes behavior the node no longer has

The doc says a seedless build "silently builds this — ... Nothing errors; the node just logs `MARSHAL-ONLY BUILD DETECTED`." The node now (correctly, fail-closed) **refuses to start** unverified without `DREGG_ALLOW_UNVERIFIED_CONSENSUS=1` — so the doc's marshal-only run example doesn't start at all as written. The paragraph now describes the explicit opt-in gate and the run example includes the env var.

## 3. QUICKSTART §3's faucet example can brick signing on a data dir missing its operator cell

The faucet accepts an optional `public_key`; when it materializes a **new** cell without one, the cell gets a zero public key, and the faucet never rewrites an existing cell's key (`provision_recipient` early-returns) — signature verification against that cell fails forever. On a healthy boot the operator cell already exists with its key, so the documented no-key faucet call is usually harmless — but on a data dir whose operator cell is missing (the refused-first-launch state, fixed separately in the companion PR "node: refuse marshal-only BEFORE touching the data dir"), this exact documented command is what bricks the node. The example now captures the node's pubkey and passes it, with the trap documented in place.

## How found

Ran the quickstart by hand on a clean clone (WSL2/Ubuntu 24.04, marshal-only build since no Lean seed release exists), ended up with a node whose every signed turn failed `Ed25519 signature verification failed` — while `dregg demo` reported a fully successful lifecycle.

## Provenance

Agent-assisted: keeminlee working with a Claude agent (fable-jetto); the human reviewed and can answer for every line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
