### PR TITLE
node: refuse marshal-only BEFORE touching the data dir

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -794,6 +794,68 @@ async fn run_node(
         tracing::warn!("Running in DEVNET mode \u{2014} keys are not production-grade");
     }
 
+    // ── MARSHAL-ONLY STARTUP TRIPWIRE (fail-CLOSED refusal) ───────────────────
+    // A binary linked WITHOUT the verified Lean executor archive (libdregg_lean.a)
+    // runs the UN-verified Rust executor: `dregg_lean_ffi::lean_available()` is false.
+    // Such a build must NEVER deploy silently as if it were the verified node — a
+    // stale or gitignored Lean seed degrades the whole executor to marshal-only with
+    // no other visible signal. Historically this tripwire was LOG-ONLY (an `error!`),
+    // so a *solo* node whose logs were ignored could still serve its API presenting as
+    // verified. It is now fail-CLOSED: any node (solo OR full) REFUSES to start
+    // (`exit(1)`) when the verified executor is not linked, UNLESS the operator
+    // explicitly accepts the un-verified executor with `DREGG_ALLOW_UNVERIFIED_CONSENSUS=1`
+    // (the same escape hatch the verified-consensus hard-check below uses). This makes an
+    // unverified node a DELIBERATE opt-in, never a silent default. (See
+    // docs/BUILD-LEAN-LINKED-NODE.md.)
+    //
+    // The refusal must also be SIDE-EFFECT-FREE, so it runs HERE — before
+    // `NodeState` construction touches the data dir. When it ran after state
+    // construction + devnet seeding, a refused first launch left a partially
+    // initialized data dir: the relaunch (with the opt-in set) took the
+    // recovery path instead of the fresh-boot path and never provisioned the
+    // operator's agent cell. The first `/api/faucet` call without `public_key`
+    // then materialized that cell as a zero-key stub, and every signed turn on
+    // that data dir failed "Ed25519 signature verification failed" forever
+    // (the faucet never rewrites an existing cell's key). Reproduced
+    // end-to-end: clean boot → agent cell present with the operator key;
+    // refused-launch-then-relaunch → agent cell absent.
+    let lean_available = dregg_lean_ffi::lean_available();
+    let allow_unverified = env_allow_unverified(
+        std::env::var("DREGG_ALLOW_UNVERIFIED_CONSENSUS")
+            .ok()
+            .as_deref(),
+    );
+    if !lean_available {
+        if !marshal_only_must_refuse(lean_available, allow_unverified) {
+            tracing::warn!(
+                "MARSHAL-ONLY BUILD OVERRIDDEN: `dregg_lean_ffi::lean_available()` is false — this \
+                 binary was linked WITHOUT the verified Lean executor archive (libdregg_lean.a) and \
+                 is running the UN-VERIFIED Rust executor. DREGG_ALLOW_UNVERIFIED_CONSENSUS is set, \
+                 so the node will proceed on the un-verified executor. Its state transitions are NOT \
+                 shadowed by the proved Lean kernel — do not present this node as verified."
+            );
+        } else {
+            error!(
+                "REFUSING TO START: `dregg_lean_ffi::lean_available()` is false — this binary was \
+                 linked WITHOUT the verified Lean executor archive (libdregg_lean.a) and would run \
+                 the UN-VERIFIED Rust executor. A node (solo OR full) MUST NOT serve as if verified \
+                 while running the un-verified executor. Rebuild against a closure-complete, \
+                 HEAD-matching Lean archive: `./scripts/bootstrap.sh` (and set DREGG_REQUIRE_LEAN=1 \
+                 in CI/distribution builds so a marshal-only degrade fails the build instead of \
+                 shipping silently — a --release build now defaults that gate ON). To deliberately \
+                 run an un-verified node, set DREGG_ALLOW_UNVERIFIED_CONSENSUS=1. A stale or \
+                 gitignored seed silently degrades to marshal-only — see \
+                 docs/BUILD-LEAN-LINKED-NODE.md."
+            );
+            std::process::exit(1);
+        }
+    } else {
+        info!(
+            "verified-executor archive linked: `dregg_lean_ffi::lean_available()` is true — this \
+             node runs the PROVED Lean executor over the C ABI"
+        );
+    }
+
     // Initialize node state with configurable key file.
     let has_peers = !peers.is_empty();
     let node_state = match state::NodeState::new_with_key_file(&data_path, peers, key_file) {
@@ -1059,56 +1121,6 @@ async fn run_node(
                 committee_size, "federation mode: full — BFT quorum required for finality"
             );
         }
-    }
-
-    // ── MARSHAL-ONLY STARTUP TRIPWIRE (fail-CLOSED refusal) ───────────────────
-    // A binary linked WITHOUT the verified Lean executor archive (libdregg_lean.a)
-    // runs the UN-verified Rust executor: `dregg_lean_ffi::lean_available()` is false.
-    // Such a build must NEVER deploy silently as if it were the verified node — a
-    // stale or gitignored Lean seed degrades the whole executor to marshal-only with
-    // no other visible signal. Historically this tripwire was LOG-ONLY (an `error!`),
-    // so a *solo* node whose logs were ignored could still serve its API presenting as
-    // verified. It is now fail-CLOSED: any node (solo OR full) REFUSES to start
-    // (`exit(1)`) when the verified executor is not linked, UNLESS the operator
-    // explicitly accepts the un-verified executor with `DREGG_ALLOW_UNVERIFIED_CONSENSUS=1`
-    // (the same escape hatch the verified-consensus hard-check below uses). This makes an
-    // unverified node a DELIBERATE opt-in, never a silent default. (See
-    // docs/BUILD-LEAN-LINKED-NODE.md.)
-    let lean_available = dregg_lean_ffi::lean_available();
-    let allow_unverified = env_allow_unverified(
-        std::env::var("DREGG_ALLOW_UNVERIFIED_CONSENSUS")
-            .ok()
-            .as_deref(),
-    );
-    if !lean_available {
-        if !marshal_only_must_refuse(lean_available, allow_unverified) {
-            tracing::warn!(
-                "MARSHAL-ONLY BUILD OVERRIDDEN: `dregg_lean_ffi::lean_available()` is false — this \
-                 binary was linked WITHOUT the verified Lean executor archive (libdregg_lean.a) and \
-                 is running the UN-VERIFIED Rust executor. DREGG_ALLOW_UNVERIFIED_CONSENSUS is set, \
-                 so the node will proceed on the un-verified executor. Its state transitions are NOT \
-                 shadowed by the proved Lean kernel — do not present this node as verified."
-            );
-        } else {
-            error!(
-                "REFUSING TO START: `dregg_lean_ffi::lean_available()` is false — this binary was \
-                 linked WITHOUT the verified Lean executor archive (libdregg_lean.a) and would run \
-                 the UN-VERIFIED Rust executor. A node (solo OR full) MUST NOT serve as if verified \
-                 while running the un-verified executor. Rebuild against a closure-complete, \
-                 HEAD-matching Lean archive: `./scripts/bootstrap.sh` (and set DREGG_REQUIRE_LEAN=1 \
-                 in CI/distribution builds so a marshal-only degrade fails the build instead of \
-                 shipping silently — a --release build now defaults that gate ON). To deliberately \
-                 run an un-verified node, set DREGG_ALLOW_UNVERIFIED_CONSENSUS=1. A stale or \
-                 gitignored seed silently degrades to marshal-only — see \
-                 docs/BUILD-LEAN-LINKED-NODE.md."
-            );
-            std::process::exit(1);
-        }
-    } else {
-        info!(
-            "verified-executor archive linked: `dregg_lean_ffi::lean_available()` is true — this \
-             node runs the PROVED Lean executor over the C ABI"
-        );
     }
 
     // ── VERIFIED-CONSENSUS STARTUP HARD-CHECK (red-team parity #6/#7) ──────────


### PR DESCRIPTION
## The bug

The fail-closed marshal-only tripwire ran **after** `NodeState` construction and devnet seeding. A refused launch is therefore not a no-op: it initializes the data dir, provisions cells in memory (including the operator's agent cell, with its public key), and then exits partway through. The relaunch — now with `DREGG_ALLOW_UNVERIFIED_CONSENSUS=1` set — finds an existing store, takes the recovery path instead of the fresh-boot path, and **never provisions the operator agent cell**.

The first `/api/faucet` call against that missing cell (QUICKSTART §3's own command, without `public_key`) then materializes it as a **zero-key stub** — and since the faucet never rewrites an existing cell's key (`provision_recipient` early-returns), every signed turn on that data dir fails `Ed25519 signature verification failed` forever: QUICKSTART §3's signed-turn example and every mutating step of `dregg demo` reject, with nothing pointing at the cause.

## Reproduced end-to-end

Clean clone, marshal-only build (no Lean seed release exists), WSL2/Ubuntu 24.04:

| Sequence | Operator agent cell after boot |
|---|---|
| clean single boot (opt-in set) | `found: true`, `public_key` = operator key, balance 0 |
| refused launch (no opt-in, exit 1), then relaunch (opt-in set) | `found: false` |
| … + faucet without `public_key` | zero-key stub; signing bricked permanently |

This is not hypothetical — it is exactly how our first node got bricked: first launch refused (env var not yet set), relaunched with the override, followed §3, then spent the evening tracing the signature failure.

## The fix

Hoist the tripwire above `NodeState` construction, so **refusal is side-effect-free** — a refused launch leaves the data dir exactly as it found it, and the relaunch behaves like a first boot. The check reads only `dregg_lean_ffi::lean_available()` and one env var, so it needs no state; `lean_available` / `allow_unverified` stay in scope for the verified-consensus hard-check below, which does need state and stays where it was. The block's logic is unchanged — this is a move, plus a comment explaining why position is load-bearing.

Re-ran the same A/B after the fix: refused-launch-then-relaunch now boots identical to a clean boot (`found: true`, operator key set).

An alternative would be teaching the recovery path to re-provision the operator cell, but that treats one symptom and leaves every other artifact of a mid-boot exit in place; a side-effect-free refusal fixes the class.

## Behavior notes

- Lean-linked builds: unchanged — the block logs the same info line in both positions.
- Refused case: strictly less happens before exit than before.
- Companion PRs: #24 (status honesty on marshal-only builds), #25 (quickstart/demo fail-loud + the `public_key` faucet idiom that hardens against exactly this state).

## Provenance

Agent-assisted: keeminlee working with a Claude agent (fable-jetto); the human reviewed and can answer for every line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
