### PR TITLE
fix(net): fail closed on captp magic and mtls allowlist

### DIFF
--- a/captp/src/store_forward.rs
+++ b/captp/src/store_forward.rs
@@ -752,11 +752,13 @@ impl BlocklaceEnvelope {
     /// cannot be deserialized.
     pub fn from_payload(payload: &[u8]) -> Option<Self> {
         if payload.len() < 4 || payload[..4] != Self::MAGIC {
-            // Quick check: raw postcard doesn't have the magic as a prefix,
-            // but the serialized struct does (it's the first field).
-            // Try deserializing anyway.
+            return None;
         }
-        postcard::from_bytes(payload).ok()
+        let envelope: Self = postcard::from_bytes(payload).ok()?;
+        if envelope.magic != Self::MAGIC {
+            return None;
+        }
+        Some(envelope)
     }
 
     /// Check if this envelope is addressed to us.
@@ -1336,6 +1338,22 @@ mod tests {
         assert_eq!(results[0], (0, b"msg-zero".to_vec()));
         assert_eq!(results[1], (1, b"msg-one".to_vec()));
         assert_eq!(results[2], (2, b"msg-two".to_vec()));
+    }
+
+    #[test]
+    fn blocklace_bad_magic_is_skipped_without_decrypt_error() {
+        let (bob_secret, bob_public) = test_x25519_keypair();
+        let (alice_secret, _) = test_x25519_keypair();
+
+        let mut payload_bytes =
+            queue_via_blocklace(fed_bob(), b"secret", &bob_public, &alice_secret, 7);
+        payload_bytes[0] ^= 0x01;
+
+        assert!(BlocklaceEnvelope::from_payload(&payload_bytes).is_none());
+
+        let results = scan_and_decrypt_blocklace(&[payload_bytes], &fed_bob(), &bob_secret)
+            .expect("bad magic should be skipped before decrypt");
+        assert!(results.is_empty());
     }
 
     #[test]

--- a/net/src/node.rs
+++ b/net/src/node.rs
@@ -48,6 +48,7 @@ pub struct PeerNode {
     node_id: NodeId,
     local_addr: SocketAddr,
     cert_der: Vec<u8>,
+    key_der: Vec<u8>,
     /// Maximum concurrent connections enforced by this node.
     max_connections: usize,
     /// Rate limiter for incoming connections.
@@ -209,6 +210,7 @@ impl PeerNode {
             node_id,
             local_addr,
             cert_der,
+            key_der,
             max_connections: config.max_connections,
             rate_limiter,
         })
@@ -397,9 +399,10 @@ impl PeerNode {
     /// is in the provided allowlist. Use `AllowlistVerifier::allow_node()` to pre-authorize
     /// peers before connecting.
     pub fn build_client_config_with_allowlist(
+        &self,
         verifier: &AllowlistVerifier,
     ) -> Result<ClientConfig, PeerError> {
-        verifier.build_client_config()
+        verifier.build_client_config_with_cert(&self.cert_der, &self.key_der)
     }
 
     /// Build a client config for the gossip layer that presents a fresh ephemeral
@@ -725,8 +728,16 @@ impl AllowlistVerifier {
         self.allowed_node_ids.read().unwrap().contains(node_id)
     }
 
-    /// Build a `ClientConfig` that verifies peers against this allowlist.
-    pub fn build_client_config(&self) -> Result<ClientConfig, PeerError> {
+    /// Build a `ClientConfig` that presents the caller's certificate and
+    /// verifies peers against this allowlist.
+    fn build_client_config_with_cert(
+        &self,
+        cert_der: &[u8],
+        key_der: &[u8],
+    ) -> Result<ClientConfig, PeerError> {
+        let cert = CertificateDer::from(cert_der.to_vec());
+        let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_der.to_vec()));
+
         let mut client_crypto = rustls::ClientConfig::builder_with_provider(Arc::new(
             rustls::crypto::ring::default_provider(),
         ))
@@ -734,14 +745,16 @@ impl AllowlistVerifier {
         .map_err(|e| PeerError::Tls(e.to_string()))?
         .dangerous()
         .with_custom_certificate_verifier(Arc::new(self.clone()))
-        .with_no_client_auth();
+        .with_client_auth_cert(vec![cert], key)
+        .map_err(|e| PeerError::Tls(e.to_string()))?;
 
         client_crypto.alpn_protocols = vec![DREGG_ALPN.to_vec()];
 
-        let client_config = ClientConfig::new(Arc::new(
+        let mut client_config = ClientConfig::new(Arc::new(
             quinn::crypto::rustls::QuicClientConfig::try_from(client_crypto)
                 .map_err(|e| PeerError::Tls(e.to_string()))?,
         ));
+        client_config.transport_config(peer_transport_config());
         Ok(client_config)
     }
 }
@@ -818,7 +831,7 @@ impl rustls::client::danger::ServerCertVerifier for AllowlistVerifier {
 /// - No identity pinning (peer rotation is allowed)
 ///
 /// **To enable certificate pinning for gossip**, use:
-/// `PeerNode::build_client_config_with_allowlist(&verifier)` instead of
+/// `peer_node.build_client_config_with_allowlist(&verifier)` instead of
 /// `PeerNode::build_client_config_static()`.
 #[derive(Debug)]
 struct GossipCertVerifier;
@@ -978,6 +991,67 @@ mod tests {
         verifier.deny_node(&node_id);
         let result = verifier.verify_server_cert(&cert, &[], &server_name, &[], UnixTime::now());
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn allowlisted_quic_peer_presents_client_cert_and_connects() {
+        let server = PeerNode::new(PeerNodeConfig::default()).await.unwrap();
+        let client = PeerNode::new(PeerNodeConfig::default()).await.unwrap();
+
+        let verifier = AllowlistVerifier::new([server.node_id()]);
+        let client_config = client
+            .build_client_config_with_allowlist(&verifier)
+            .unwrap();
+        let connecting = client
+            .endpoint()
+            .connect_with(client_config, server.local_addr(), "dregg.local")
+            .unwrap();
+
+        let (client_result, server_result) =
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                tokio::join!(connecting, server.accept())
+            })
+            .await
+            .expect("allowlisted mTLS connection should complete");
+
+        let client_connection =
+            client_result.expect("client should accept allowlisted server cert");
+        let server_connection = server_result.expect("server should accept client cert");
+
+        assert_eq!(
+            extract_remote_id(&client_connection).unwrap(),
+            server.node_id()
+        );
+        assert_eq!(server_connection.remote_id(), client.node_id());
+
+        client_connection.close(0u8.into(), b"done");
+        server_connection.close();
+        client.close();
+        server.close();
+    }
+
+    #[tokio::test]
+    async fn non_allowlisted_quic_peer_is_rejected() {
+        let server = PeerNode::new(PeerNodeConfig::default()).await.unwrap();
+        let server_addr = server.local_addr();
+        let client = PeerNode::new(PeerNodeConfig::default()).await.unwrap();
+
+        let verifier = AllowlistVerifier::empty();
+        let client_config = client
+            .build_client_config_with_allowlist(&verifier)
+            .unwrap();
+        let accept_task = tokio::spawn(async move { server.accept().await });
+        let connecting = client
+            .endpoint()
+            .connect_with(client_config, server_addr, "dregg.local")
+            .unwrap();
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(5), connecting)
+            .await
+            .expect("non-allowlisted peer should fail promptly");
+        assert!(result.is_err());
+        accept_task.abort();
+        client.close();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fail closed in `BlocklaceEnvelope::from_payload`: reject payloads whose leading bytes do not match `BlocklaceEnvelope::MAGIC`, and re-check the decoded struct's `magic` field before accepting it.
- Make the allowlist QUIC client config present the caller `PeerNode` certificate/key while using `AllowlistVerifier` to pin the remote certificate.
- Add regressions for bad blocklace magic skip-without-decrypt and allowlisted/non-allowlisted QUIC mTLS behavior.

## Verification
- `fab build -- cargo test -p dregg-captp blocklace_bad_magic_is_skipped_without_decrypt_error -- --nocapture` PASS
- `fab build -- cargo test -p dregg-net allowlisted_quic_peer_presents_client_cert_and_connects -- --nocapture` PASS
- `fab build -- cargo test -p dregg-net non_allowlisted_quic_peer_is_rejected -- --nocapture` PASS
- `fab build -- cargo test -p dregg-captp -p dregg-net -- --nocapture` PASS (`dregg-captp`: 200 unit + integration/doc tests; `dregg-net`: 97 unit + doc/bin tests)
- `fab build -- cargo fmt --check` PASS
- `fab build -- cargo check -p dregg-captp -p dregg-net` PASS
- `git diff --check -- captp/src/store_forward.rs net/src/node.rs` PASS

## Note
`fab build -- cargo check --workspace` was attempted and failed before reaching this code on the build host because `yeslogic-fontconfig-sys` could not find system `fontconfig.pc`. The touched packages compile and test green under fab.
