### PR TITLE
bootstrap: honor absolute mathlib pins + catch lakefile/manifest disagreement before lake runs

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -50,14 +50,43 @@ step "Checking the mathlib path dependency"
 
 MATHLIB_REL="$(sed -n 's/^path = "\(.*\)"/\1/p' "$META/lakefile.toml" | head -1)"
 [ -n "$MATHLIB_REL" ] || die "could not read the mathlib path from $META/lakefile.toml"
-MATHLIB_DIR="$META/$MATHLIB_REL"
+# An absolute pin must not be joined onto $META — "$META//abs/path" exists on nobody's
+# machine (the FATAL a repointed-to-absolute lakefile used to produce here). Relative
+# pins resolve against metatheory/, matching lake.
+case "$MATHLIB_REL" in
+  /*) MATHLIB_DIR="$MATHLIB_REL" ;;
+  *)  MATHLIB_DIR="$META/$MATHLIB_REL" ;;
+esac
 # The pinned revision is named in the lakefile comment (a 40-hex sha).
 MATHLIB_REV="$(grep -oE '[0-9a-f]{40}' "$META/lakefile.toml" | head -1 || true)"
 
+# lake resolves the dependency from lake-manifest.json, NOT the lakefile: a lakefile
+# repoint with a stale manifest passes every check below and then fails the lake build
+# with a path this script never looked at ("package directory not found: <old pin>").
+# Catch the disagreement here, where the fix can be taught.
+MANIFEST="$META/lake-manifest.json"
+if [ -f "$MANIFEST" ]; then
+  MANIFEST_DIR="$(awk '/"name": "mathlib"/{f=1} f && /"dir":/{sub(/.*"dir": "/,""); sub(/",?.*/,""); print; exit}' "$MANIFEST")"
+  if [ -n "$MANIFEST_DIR" ] && [ "$MANIFEST_DIR" != "$MATHLIB_REL" ]; then
+    die "mathlib path DISAGREEMENT between the lakefile and the lake manifest:
+      metatheory/lakefile.toml       pins   path = \"$MATHLIB_REL\"
+      metatheory/lake-manifest.json  locks  \"dir\": \"$MANIFEST_DIR\"
+
+  lake resolves the dependency from the MANIFEST, so the lakefile pin alone never
+  takes effect — the lake build below would fail with:
+      error: mathlib: package directory not found: $MANIFEST_DIR
+
+  Fix: point BOTH files at the same mathlib checkout (edit the \"dir\" of the mathlib
+  entry in metatheory/lake-manifest.json to match the lakefile), then re-run."
+  fi
+fi
+
 if [ ! -f "$MATHLIB_DIR/lakefile.lean" ]; then
   die "mathlib checkout MISSING at: $MATHLIB_DIR
-  (metatheory/lakefile.toml pins mathlib as the local path '$MATHLIB_REL', resolved
-  relative to metatheory/. Nothing Lean builds until it exists.)
+  (metatheory/lakefile.toml pins mathlib as the local path '$MATHLIB_REL' — relative
+  pins resolve against metatheory/. With the repo's default pin that expects the
+  sibling layout <root>/src/dregg + <root>/src/mathlib4; an absolute pin is honored
+  as-is. Nothing Lean builds until it exists.)
 
   Put it there at the pinned revision:
       git clone https://github.com/leanprover-community/mathlib4 \"$MATHLIB_DIR\"


### PR DESCRIPTION
Two path layers can disagree with what `scripts/bootstrap.sh` actually checks, and both were hit live while bootstrapping the verified executor on a fresh WSL2 host this week (clone at `~/dregg`, mathlib at `/root/src/mathlib4`):

**1. Absolute pins were joined onto `$META`.** `MATHLIB_DIR="$META/$MATHLIB_REL"` turns an absolute `path =` pin into `$META//abs/path` — a directory that exists on nobody's machine — so the script FATALed on a checkout that was present and at the pinned rev. Absolute pins are now honored as-is; relative pins resolve against `metatheory/` exactly as before (and exactly as lake does).

**2. lake resolves mathlib from `lake-manifest.json`, not the lakefile.** A lakefile repoint with a stale manifest passes every bootstrap check, then fails minutes later inside `lake build` with `package directory not found: <old pin>` — a path the script never looked at, which makes the pin-check output actively misleading. The manifest's mathlib `dir` is now compared against the lakefile pin up front; a disagreement dies immediately with a message that names both files and teaches the fix.

Also names the sibling layout the repo's default relative pin expects (`<root>/src/dregg` + `<root>/src/mathlib4`) in the missing-checkout message, so a clone at any other location learns its options instead of a bare path.

**Verification** (all on the patched script):
- attempt-2 state reproduced (lakefile absolute, manifest stale) → immediate DISAGREEMENT die naming both files and predicting the exact lake error
- absolute pin with agreeing manifest → passes the check, proceeds to `lake build`
- absolute pin, no manifest file present → passes (no more `$META//` join FATAL)
- default relative pin, checkout missing → MISSING die with the layout note
- full re-run on the already-bootstrapped tree → completes to `DONE`, kernel round-trip OK (`lean_available()=true` node built from the resulting seed is serving now)

Agent-assisted provenance, same as #24–#26: authored with Claude (Fable 5) under my direction and live verification.