### PR TITLE
fix(lean-ffi): raise closure-completion pass bound 16→64 (fresh-clone verified builds fail to link at HEAD)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -42,6 +42,7 @@ below are the same steps by hand. Full detail: `docs/LEAN-SEED-ARTIFACT.md` and
 ```sh
 # 1. elan + the pinned Lean toolchain on PATH (installs in minutes; NO mathlib compile):
 curl https://elan.lean-lang.org/elan-init.sh -sSf | sh    # then re-open your shell
+# (Linux/Ubuntu: the gpui link also needs the xkbcommon X11 dev symlink: apt install libxkbcommon-x11-dev)
 # 2. fetch the prebuilt Lean seed for your platform (minutes, not the hours-long bootstrap):
 ./scripts/fetch-lean-seed.sh
 # 3. build the node, FAILING LOUD if it would silently degrade to marshal-only:

--- a/dregg-lean-ffi/build.rs
+++ b/dregg-lean-ffi/build.rs
@@ -669,7 +669,7 @@ fn complete_initializer_closure(meta: &Path, sysroot: &Path, archive: &Path, out
     let roots = discover_ir_roots(meta);
     let index = build_cfile_index(&roots);
 
-    for pass in 0..16 {
+    for pass in 0..64 {
         let undefined = undefined_initializers(archive);
         if undefined.is_empty() {
             return;
@@ -732,7 +732,7 @@ fn complete_initializer_closure(meta: &Path, sysroot: &Path, archive: &Path, out
         );
     }
     println!(
-        "cargo:warning=dregg-lean-ffi: closure completion hit the 16-pass bound — archive may \
+        "cargo:warning=dregg-lean-ffi: closure completion hit the 64-pass bound — archive may \
          still have undefined initializers. Consider re-seeding the closure."
     );
 }


### PR DESCRIPTION
## What breaks

Fresh clone + `./scripts/bootstrap.sh` on Linux at HEAD now produces a seed archive whose initializer closure **doesn't converge within the hardcoded 16 passes** — passes 13/14/15 were still adding 34/23/25 objects at cutoff. Every `DREGG_REQUIRE_LEAN` release link then fails:

```
rust-lld: error: undefined symbol: initialize_mathlib_Mathlib_Topology_Algebra_UniformRing
rust-lld: error: undefined symbol: initialize_mathlib_Mathlib_Combinatorics_Matroid_Dual
rust-lld: error: undefined symbol: initialize_mathlib_Mathlib_RingTheory_Valuation_ValuationSubring
…
```

The DEBT-A work deepened the mathlib dependency closure past what 16 passes reach. (The `DistributedExports` Coord fix from the 7-10 report works, for the record — the `ar` failure is gone; this is the next gate behind it.)

## Fix

One line: `for pass in 0..16` → `0..64` (+ the matching warning text). 64 converges at today's HEAD with room to grow. A follow-up you may prefer instead: exit on a no-progress pass rather than any fixed bound — happy to rework if so.

## Verified

Ubuntu x86_64 (24-core), fresh clone at `9b4cfd1c1`, sibling plonky3-recursion at `993efec`:
- bootstrap → 181M `libdregg_lean.a` (8571 objects)
- verified `starbridge-v2` release link (degrade-guard active, no `DREGG_REQUIRE_LEAN=0`)
- `--headless` → exit 0, `VERDICT ✓`, and `ML-DSA verify: verified Lean core installed … fips204 out of starbridge-v2's verify TCB`
- cockpit window opens on Wayland/GNOME; WEB-SHELL renders lunar.town through the cap-gated Servo WebView with `executor: embedded verified (TurnExecutor)`

Also bundles the one-line QUICKSTART note from that run: Ubuntu needs `libxkbcommon-x11-dev` (runtime `.so.0` ships with the distro; the linkable `.so` doesn't).

## Offer: Linux seed artifact

We have the resulting 181M Linux x86_64 seed built from your HEAD — usable as the first `lean-seed.pin` release if you want it (`TAG=` is still empty and `fetch-lean-seed.sh` fails loud on fresh clones). Say the word and David can get it to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136GaMKBL2rfbjt98ykdPDT
