### PR TITLE
fix(node): fail cleanly on a malformed node.key instead of a slice panic

### DIFF
--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1931,6 +1931,15 @@ async fn run_relay(
     let operator_key = if data_path.join("node.key").exists() {
         let key_bytes = std::fs::read(data_path.join("node.key"))
             .expect("failed to read node.key for relay operator identity");
+        if key_bytes.len() != 32 {
+            error!(
+                "node.key in {} is malformed: expected 32 bytes, found {}. \
+                 Re-run `dregg-node init`.",
+                data_path.display(),
+                key_bytes.len()
+            );
+            std::process::exit(1);
+        }
         let mut key = [0u8; 32];
         key.copy_from_slice(&key_bytes[..32]);
         key


### PR DESCRIPTION
## What's wrong

`node/src/lib.rs` reads the relay operator's `node.key` and slices the first 32 bytes without checking the length:

```rust
let key_bytes = std::fs::read(data_path.join("node.key"))
    .expect("failed to read node.key for relay operator identity");
let mut key = [0u8; 32];
key.copy_from_slice(&key_bytes[..32]);   // panics if node.key < 32 bytes
```

If `node.key` exists but is shorter than 32 bytes — an interrupted `dregg-node init`, a disk-full write, manual corruption — `&key_bytes[..32]` panics with a raw `range end index 32 out of range for slice of length N`. That's the opposite of what the surrounding code intends: the adjacent *missing*-key branch already fails cleanly with `error!(...)` + `exit(1)` ("no node.key found … Run `dregg-node init`"). A malformed key should fail the same graceful, actionable way — not crash with a slice panic.

The codebase already knows the right pattern: `node/src/starbridge_seed.rs` (`load_agent_secret_key`) does the same file-read-then-`copy_from_slice` but guards it with `if bytes.len() < 32 { return None; }` first. This just brings the operator-key read in line.

## Fix

Add an exact-length check before the copy; on a wrong-length key, emit the same `error!` + `exit(1)` the missing-key branch uses. As a bonus it also stops silently truncating an *oversized* key to its first 32 bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136GaMKBL2rfbjt98ykdPDT
