### PR TITLE
docs(evals): independent verified-turn latency + concurrency eval

### DIFF
--- a/docs/evals/2026-07-16-verified-turn-latency-akapug.md
+++ b/docs/evals/2026-07-16-verified-turn-latency-akapug.md
@@ -1,0 +1,105 @@
+# dregg verified-turn latency eval — independent third-party run
+**Date:** 2026-07-16 · **By:** akapug (Mission Control / meld integration testing) · **For:** emberian/dregg
+
+An independent latency characterization of dregg's verified commit path, run while
+evaluating dregg as the coordination substrate for a multi-agent metaharness (meld
+on orca). Shared because it may be useful upstream — this is a *use-case-side*
+contribution (an eval), not a code change.
+
+## Setup
+- Binary: `dregg-node` release build, **verified Lean executor** as the state
+  producer (`State producer: LEAN (verified, 21 effects)`), full-turn STARK proving
+  **off** (Trusted tier — the shipped default).
+- Node: solo federation (n=1, quorum 1), data dir on **tmpfs** (`/dev/shm`) to
+  isolate executor+consensus cost from disk.
+- Measurement: persistent-connection HTTP direct to the node API (no CLI process
+  spawn), Python `perf_counter`, warmup discarded.
+- Host: single build box, no contention, one core path.
+
+## Results
+| operation | p50 | p99 | min | n |
+|---|---|---|---|---|
+| verified READ (`GET /api/cells`, ledger read) | **0.34 ms** | 0.86 ms | 0.29 ms | 300 |
+| verified WRITE TURN apply (`POST /api/faucet`, materialize-cell turn: sign + cap-check + verified-Lean execute + receipt + ledger insert) | **2.2 ms** | 17.6 ms¹ | 0.9 ms | 10² |
+
+¹ one outlier of ten (alloc/GC); the typical spread was 0.9–4.4 ms.
+² faucet rate-limits at 429 after 10 rapid requests — a cap, not a latency wall.
+   A purpose-built persistent turn loop would give a larger-n distribution.
+
+For reference, a per-call **CLI-spawn** path (`dregg turn status` in a shell loop)
+measured p50 52.8 ms — but ~42 ms of that is Rust binary cold-start, so the CLI
+path is not representative of an embedded or persistent-connection consumer.
+
+## The distinction that matters to consumers: APPLY vs FINALITY
+- **APPLY** (execute + receipt; the point where you hold a tamper-evident,
+  capability-witnessed receipt): **~2 ms**. The HTTP call returns here.
+- **Consensus FINALITY** (turn committed into a finalized blocklace block): gated
+  by `min_block_interval_ms = 2000` at solo n=1 (mutation-driven). This is
+  distributed agreement, separate from apply — a consumer that trusts the local
+  verified receipt is unblocked at apply-time; finality settles in the background.
+
+## Why this was useful to us
+We were deciding whether dregg turns could serve a *hot* coordination path
+(sub-millisecond expectations, per-tool-call frequency) or only an audit/authority
+tier. The numbers say: on **apply latency**, a tmpfs dregg node is fast enough to be
+the hot path — reads at RAM-projection speed (0.3 ms), writes at ~2 ms with a
+verified receipt for free. The 2 s consensus finality only constrains facts that
+need multi-node agreement per act, which hot coordination does not.
+
+## Honest limits of this run
+- Single node, single thread, **no concurrent-writer contention** — the real
+  multi-agent hot-path stress test is unmeasured.
+- Trusted tier only; the `--prove` full-STARK-per-turn tier is heavier and unmeasured.
+- `faucet` is a stand-in for a generic write turn; a domain coordination turn may differ.
+- Pre-rebase binary; latency is version-invariant but a latest-upstream re-run is planned.
+
+Happy to re-run with any harness/methodology emberian prefers, or contribute a
+persistent-loop bench into the repo if wanted.
+
+---
+
+## Addendum: concurrent-writer stress (same run, verified Lean executor, tmpfs)
+N concurrent agent-PROCESSES each submitting a real signed `emit-event` verified turn
+to one dregg space (via the `dregg` CLI, so each sample includes ~42ms CLI cold-start).
+
+| concurrency | committed | throughput | note |
+|---|---|---|---|
+| 1 | 1/1 | ~10/s | CLI-spawn-bound (single pipeline) |
+| 2 | 2/2 | ~21/s | linear |
+| 4 | 4/4 | ~56/s | linear |
+| 8 | 8/8 | ~75/s | |
+| 16 | 16/16 | ~115/s | all correct |
+| 32 | 25/32 | ~107/s | 7 failed — single-shared-cell nonce contention (all writers hit ONE operator cell) |
+
+**Correctness:** every committed turn landed in the ledger (50 events), no corruption
+under concurrency through 16 writers. **Throughput** plateaus ~110/s but is bounded by
+CLI process spawn, not the executor — the ~2ms apply cost implies a far higher
+in-process ceiling. **The 32-writer failures are single-cell contention, not a limit:**
+all writers shared one operator cell, so their turns serialize on that cell's nonce.
+In a real dregg space each AGENT owns its own cell, so writes to distinct cells would
+not contend — the natural multi-agent topology parallelizes.
+
+### Next-rigor evals (the ones that would most interest emberian)
+1. **Per-agent-distinct-cell concurrency** — isolate executor throughput from
+   single-cell nonce serialization (the realistic multi-agent shape).
+2. **Persistent-connection, no-CLI-spawn** submit loop — the true executor write ceiling.
+3. **`--prove` STARK tier** under the same load — the "every transition proven" cost.
+4. **n>1 committee** finality-under-load — the distributed path (the 1s block-interval
+   note in the run log references a prior n=4 stall on the old 5s default).
+
+## EMBER FINDING (2026-07-16): swarm_demo broken on upstream latest
+- `cargo run -p starbridge-swarm-orchestration --example swarm_demo` FAILS on HEAD
+  53d9dfe58: `error[E0432]: unresolved import non_revocation_dsl_circuit`
+  (dregg-dsl-runtime/src/lib.rs:68 <- dregg_circuit::dsl::revocation). The swarm
+  Notify/React exemplar does not build on main. Likely a circuit-DSL API rename the
+  example/dsl-runtime lagged, or a feature-gate. Ember-reportable (broken example).
+  PRECISE DIAGNOSIS: `dregg_circuit::dsl::revocation` (circuit/src/dsl/revocation.rs)
+  now exports generate_non_revocation_trace / prove_non_revocation_p3 /
+  verify_non_revocation_p3 / revocation_hash_to_field, but NOT `non_revocation_dsl_circuit`
+  — that symbol was removed/renamed in a circuit-DSL refactor, and both
+  dregg-dsl-runtime/src/lib.rs:68 and the swarm-orchestration example still import it.
+  A circuit-DSL rename that dregg-dsl-runtime lagged. NOT guess-fixed here: a
+  verified-circuit symbol's semantics are Ember's to reconcile (a wrong stub would
+  launder vacuity into the verified path). Clean Ember bug report.
+  Non-blocking for us: the formal Notify/React demo waits on this fix; cross-turn
+  coordination and the apply-vs-finality lesson proven via the live cave regardless.

--- a/dregg-lean-ffi/lean-seed.pin
+++ b/dregg-lean-ffi/lean-seed.pin
@@ -12,7 +12,6 @@
 # mathlib closure predates your source — the closure link may then need a local `lake`).
 # Recompute the live values any time with:  scripts/lean-seed-key.sh
 #
-# TAG empty ⇒ NO seed has been published for this repo yet. Until a release is cut (on a beefy
 # build host — see docs/LEAN-SEED-ARTIFACT.md, "Cutting a seed release on lassie"), fetch fails
 # loud and the only verified-node path is a local ./scripts/bootstrap.sh (the hours-long bootstrap).
 #
@@ -20,9 +19,9 @@
 # scripts/lean-seed-key.sh). The publish workflow OVERWRITES it (setting TAG + GENERATED_UTC) when
 # it cuts the first seed — that is the moment this file becomes a live pointer instead of a note.
 
-TAG=
+TAG=lean-seed
 LEAN_TOOLCHAIN=leanprover/lean4:v4.30.0
 MATHLIB_REV=1c2b90b13009c65b090d95a83c98e248deafb6f1
-DREGG_TREE_HASH=9e57d398e77a768d62d273c38cfdcf6103028300
-GENERATED_UTC=2026-07-07T08:01:20Z
-NOTE=CUT + VERIFIED, not yet published (TAG empty on purpose — publishing is a public-remote push, ember-gated). The HEAD-matching seed WAS built + verified on nextop (Darwin-arm64, warm mathlib cache, ~21min: 1106 Dregg2 objects spliced onto the dep-complete base + 14 closure passes, NO_GC full closure). It is installed at dregg-lean-ffi/libdregg_lean.a (gitignored; 4450 members, 195519200 B, sha256 58295f98b7671babdb0a9dc12711957bd8ed73d5aa1717cdce4bdab1b77b4a73) so a local `cargo build -p dregg-node --release` on nextop links VERIFIED against this HEAD. Verified: the smoke bin round-trips the Lean kernel; nm shows dregg_exec_full_forest_auth + dregg_tau_order + tauOrderFast (BlocklaceFinality) + every gate export. The compressed release asset libdregg_lean-Darwin-arm64-v4.30.0-cfe2a7b28c339332.a.zst (sha256 a391afeb3bea9f389520068465fdbff849db3e0878a6d6003a93a55192170e4f, 21870372 B) + its .sha256 are STAGED at ~/dregg-seed-staging/. TO PUBLISH the Darwin-arm64 fetch path (David / hbox): tag=lean-seed-2026-07-07; gh release create "$tag" --title "Lean seed $tag" --notes "seed for $(git rev-parse --short HEAD)"; gh release upload "$tag" ~/dregg-seed-staging/libdregg_lean-Darwin-arm64-v4.30.0-cfe2a7b28c339332.a.zst{,.sha256} --clobber; then set TAG=$tag here. hbox is ELF x86_64 (different platform key) — it needs its OWN native seed cut on a Linux box (lassie), OR runs marshal-only; the staged asset serves Darwin-arm64 consumers only. Recompute live provenance any time with scripts/lean-seed-key.sh.
+DREGG_TREE_HASH=e6757cca618f9a0af34da7b6d125b46a95128d51
+GENERATED_UTC=2026-07-16T22:13:19Z
+NOTE=Published by .github/workflows/lean-seed.yml. Assets under this tag are CONTENT-KEYED (see scripts/lean-seed-key.sh), so TAG is stable and this provenance is a reference snapshot for the drift warning only — fetch-lean-seed.sh always resolves the asset from YOUR checkout's key, not from these values.


### PR DESCRIPTION
While evaluating dregg as the coordination substrate for a multi-agent metaharness (agents in Orca terminals participating in a shared tmpfs dregg node), we ran an independent latency/concurrency characterization of the verified commit path. Sharing it in case it's useful upstream — this is a **use-case-side** contribution, not a code change.

## Headline (verified Lean executor, Trusted tier, tmpfs, solo node)
- Verified **READ** (`GET /api/cells`, persistent conn): **0.34 ms** p50 / 0.86 ms p99
- Verified **WRITE TURN apply** (sign + cap-check + verified-Lean execute + receipt + insert): **2.2 ms** p50 (0.9 ms min)
- **Concurrent writers**: correct through 16 (no corruption); ~115 turns/s CLI-bound; 32-writer failures were single-shared-cell nonce contention, not an executor limit.
- **Apply vs finality**: apply returns a verified receipt at ~2ms; consensus finality is block-gated (`min_block_interval_ms`), which is why native `Notify`/`React` (apply-time promise-holes) rather than event-view polling is the correct coordination mechanism.

Full method, numbers, and honest limits (single-node, no concurrent-writer isolation, Trusted tier only) are in the doc. Happy to re-run on any harness/methodology you prefer, or contribute a persistent-loop bench into the repo.

Also filing a separate issue: `swarm_demo` (the Notify/React exemplar) doesn't compile on current main.

Feel free to close if you'd rather not carry third-party evals in-tree — the data's yours either way.