### PR TITLE
fix(demo-agent): drop dead ivc_attenuation_chain example stanza + CI matrix entry

### DIFF
--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -63,7 +63,6 @@ jobs:
             offline_verification
             progressive_disclosure
             note_privacy
-            ivc_attenuation_chain
             programmable_cell
             wallet_lifecycle
             web_auth_flow

--- a/demo-agent/Cargo.toml
+++ b/demo-agent/Cargo.toml
@@ -59,9 +59,6 @@ name = "cipherclerk_lifecycle"
 name = "web_auth_flow"
 
 [[example]]
-name = "ivc_attenuation_chain"
-
-[[example]]
 name = "programmable_cell"
 
 [[example]]


### PR DESCRIPTION
## What
Two 4-line removals: the dangling `[[example]] name = "ivc_attenuation_chain"` stanza in `demo-agent/Cargo.toml`, and the matching entry in `.github/workflows/demos.yml`'s demo matrix.

## Why
The mock-IVC purge (1fdd4a671) deleted `demo-agent/examples/ivc_attenuation_chain.rs` — deliberately, per the purge-gate test's own record in `circuit-prove/tests/mock_proof_purge_gate.rs` ("…plus its dead riders: … the ivc_attenuation_chain example"). But the example stanza and the CI matrix entry survived the cut.

The dangling stanza is worse than a broken example: it makes the `dregg-demo-agent` **manifest unparseable**, which breaks cargo workspace resolution for *every* consumer at HEAD:

```
error: demo-agent/Cargo.toml: can't find `ivc_attenuation_chain` example at `examples/ivc_attenuation_chain.rs` ...
error: could not parse `dregg-demo-agent` (manifest) due to 1 previous error
```

## Verification
- `cargo metadata --no-deps` fails at HEAD (ba130602a), parses clean with this change.
- Found while running `starbridge-swarm-orchestration`'s `swarm_demo` on latest as part of real-world integration testing (same campaign as #47/#49).
- Docs mentioning the example (`TESTQALOG.md`, audit records) are historical records and deliberately left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NtwCKy7HXGgbGWnqLg2JC