### PR TITLE
sdk/privacy: thread the in-scope blinding through prove_predicate_for_fact

### DIFF
--- a/sdk/src/privacy.rs
+++ b/sdk/src/privacy.rs
@@ -518,9 +518,12 @@ impl AgentCipherclerk {
         }
         .bind(state_root);
         let bridge_predicate = Self::predicate_type_to_bridge(predicate_type, threshold.as_u32());
+        // 2026-07-16 Blinding migration (mechanical half): prove_predicate_for_fact now
+        // takes the blinding; thread the SAME in-scope value the commitment above used.
         let predicate_proof = dregg_bridge::prove_predicate_for_fact(
             attribute_value,
             binding,
+            dregg_circuit::predicate_arith_witness::Blinding(blinding),
             &bridge_predicate,
         )
         .ok_or_else(|| {


### PR DESCRIPTION
At HEAD, `dregg-sdk` fails to compile:

```
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
   --> sdk/src/privacy.rs:521:31
```

`prove_predicate_for_fact` gained a `Blinding` parameter (the unlinkability weld), but the `sdk/privacy.rs` caller wasn't migrated. This threads the blinding `prove_predicate_unlinkable` already generates for its `blinded_fact_commitment` — the same value, so commitment and proof stay bound to one blinding, matching the weld's idiom (`fresh_predicate_blinding` docs point SDK callers at exactly this).

This is the mechanical, PR-able half of the #51 compile-failure set at HEAD; the `full_turn_proof.rs` descriptor/vk sites remain yours per that issue's analysis.

Found (like #47/#49/#50/#51) running third-party integration against latest — this time wiring an external metaharness agent into a live node via the signed-envelope path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJR2SbN4f67SaYL7toXFWi