### PR TITLE
feat(gateway): a bounded context channel on admitted gate returns

### DIFF
--- a/deos-hermes/src/acp.rs
+++ b/deos-hermes/src/acp.rs
@@ -136,6 +136,13 @@ pub enum PermissionOutcome {
         /// alongside the receipt that witnesses it.
         #[serde(default)]
         paid: u64,
+        /// THE CONTEXT CHANNEL — at most one bounded (≤200B) single-line
+        /// contextual whisper riding this admitted verdict
+        /// (`sdk::tool_gateway::WhisperFrame::text`, budgets enforced at
+        /// intake). `None`/absent = no context pending — the common case, and
+        /// always the case on old nodes (additive: absent on the wire).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        whisper: Option<String>,
     },
     /// The gate REFUSED the call in-band (no turn, no spend). Maps to ACP
     /// `deny`. The `reason` names the leg that bit (scope/deadline/rate/error).

--- a/deos-hermes/src/acp_client.rs
+++ b/deos-hermes/src/acp_client.rs
@@ -688,10 +688,17 @@ pub fn permission_outcome_to_acp(outcome: &PermissionOutcome) -> Value {
     // (and Hermes's trajectory) sees exactly which mandate leg decided.
     match outcome {
         PermissionOutcome::Allow {
-            receipt, remaining, ..
+            receipt,
+            remaining,
+            whisper,
+            ..
         } => {
             sel["deosReceipt"] = json!(receipt);
             sel["deosRemaining"] = json!(remaining);
+            // THE CONTEXT CHANNEL's wire face: absent when None (additive).
+            if let Some(w) = whisper {
+                sel["deosWhisper"] = json!(w);
+            }
         }
         PermissionOutcome::Reject { reason, .. } => {
             sel["deosRefusal"] = json!(reason);

--- a/deos-hermes/src/bridge.rs
+++ b/deos-hermes/src/bridge.rs
@@ -295,6 +295,8 @@ impl<'rt> HermesGateway<'rt> {
                 receipt: hex32(&receipt.receipt.turn_hash),
                 remaining: receipt.remaining,
                 paid: receipt.paid,
+                // THE CONTEXT CHANNEL flows through: gate receipt -> ACP verdict.
+                whisper: receipt.whisper.map(|w| w.text),
             },
             Err(ToolCallError::Refused(refusal)) => PermissionOutcome::Reject {
                 tool_call_id: call.tool_call_id.clone(),

--- a/deos-hermes/src/confined_body.rs
+++ b/deos-hermes/src/confined_body.rs
@@ -162,6 +162,7 @@ fn outcome_of_verdict(verdict: &Verdict, tool_call_id: &str) -> PermissionOutcom
                 .unwrap_or_else(|| "(receipt)".into()),
             remaining: 0,
             paid: 0,
+            whisper: None,
         }
     } else {
         PermissionOutcome::Reject {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -158,6 +158,7 @@ pub mod runtime;
 pub mod service_economy;
 pub mod tool_gateway;
 pub mod trustline;
+pub mod whisper_deposit;
 pub mod turns;
 pub mod verify;
 pub mod witness_artifact;
@@ -221,7 +222,15 @@ pub use runtime::{
 // executor).
 pub use tool_gateway::{
     CALLS_MADE_SLOT, Charge, DeliveryReceipt, GatewayRefusal, RoutedHandle, RoutedResult,
-    RoutedStatus, ToolCallError, ToolGateway, ToolGrant, ToolReceipt, deleg_admit, mandate_program,
+    RoutedStatus, ToolCallError, ToolGateway, ToolGrant, ToolReceipt, WHISPER_MAX_BYTES,
+    WhisperFrame, WhisperSource, deleg_admit, mandate_program,
+};
+
+// THE CONTEXT CHANNEL's native deposit half: the cap-gated, apply-time whisper
+// deposit that backs the gateway's `WhisperSource` (replaces the tmpfs-file source).
+pub use whisper_deposit::{
+    WHISPER_SEQ_SLOT, WhisperDeposit, WhisperDepositError, WhisperInbox, WhisperWriter,
+    whisper_method,
 };
 
 // The `Payable` DSI core the metered tool-gateway charge routes through (one

--- a/sdk/src/tool_gateway.rs
+++ b/sdk/src/tool_gateway.rs
@@ -1800,4 +1800,78 @@ mod tests {
         let r3 = gw.invoke(77, 50, vec![]).expect("call 3 commits");
         assert_eq!(r3.whisper, None, "one frame delivered exactly once");
     }
+
+    #[test]
+    fn native_deposit_delivers_attributed_frame_and_cap_gate_refuses_unauthorized() {
+        use crate::whisper_deposit::{WhisperDepositError, WhisperInbox, WhisperWriter};
+
+        // THE END-TO-END NATIVE DEPOSIT: a writer's cap-gated APPLY-TIME turn
+        // deposits a frame addressed to a recipient gateway's SEAT; the recipient
+        // reads it off its next admitted call — replacing the tmpfs-file source.
+        let (rt, root) = fresh_epoch();
+        let mut gw = ToolGateway::admit(&rt, &root, seeded_grant()).expect("admit recipient gateway");
+        let seat = gw.worker_cell();
+
+        // Wire the gateway's WhisperSource to drain the native deposit inbox for
+        // THIS seat (the deposit-backed source; no tmpfs file).
+        let inbox = WhisperInbox::new();
+        gw.set_whisper_source(inbox.source_for(seat));
+
+        // AUTHORIZED writer: scoped to exactly this seat's whisper verb.
+        let mut writer =
+            WhisperWriter::admit(&rt, &root, seat, inbox.clone()).expect("admit authorized writer");
+        let line = "teammate landed the schema change — rebase before writing";
+        let dep = writer.whisper(line).expect("authorized deposit commits (apply-time)");
+        assert_eq!(
+            dep.frame.from,
+            Some(writer.writer_cell()),
+            "deposited frame is attributed to the writer's cell"
+        );
+        assert_eq!(inbox.pending(seat), 1, "one frame pending for the seat");
+
+        // The recipient gateway's NEXT admitted call carries the frame, attributed,
+        // with metering untouched (the whisper never couples to admission).
+        let r1 = gw.invoke(77, 50, vec![]).expect("recipient call 1 commits");
+        assert_eq!(
+            r1.whisper.as_ref().map(|w| w.text.as_str()),
+            Some(line),
+            "the deposited frame rides the admitted return"
+        );
+        assert_eq!(
+            r1.whisper.as_ref().and_then(|w| w.from),
+            Some(writer.writer_cell()),
+            "the `from` cell is populated from the cap-gated deposit"
+        );
+        assert_eq!(r1.calls_made, 1, "metering unchanged by the deposited whisper");
+
+        // Exactly-once: the next admitted call is back to None.
+        let r2 = gw.invoke(77, 50, vec![]).expect("recipient call 2 commits");
+        assert_eq!(r2.whisper, None, "native deposit delivered exactly once");
+
+        // UNAUTHORIZED: a writer scoped to a DIFFERENT seat cannot whisper to this
+        // seat — the executor refuses the deposit turn (cap-gate bites in-executor),
+        // and NOTHING lands in the recipient's inbox.
+        let other_seat = ToolGateway::admit(&rt, &root, seeded_grant())
+            .expect("admit a second gateway for a distinct seat")
+            .worker_cell();
+        let mut intruder = WhisperWriter::admit(&rt, &root, other_seat, inbox.clone())
+            .expect("admit a writer authorized only for the OTHER seat");
+        let refused = intruder.whisper_to(seat, "unauthorized: park at a clean point now");
+        assert!(
+            matches!(refused, Err(WhisperDepositError::Refused(_))),
+            "cap-gate refuses a deposit to a seat the writer holds no capability for: {refused:?}"
+        );
+        assert_eq!(
+            inbox.pending(seat),
+            0,
+            "a refused deposit lands no frame for the seat"
+        );
+
+        // The recipient's next admitted call sees nothing from the refused deposit.
+        let r3 = gw.invoke(77, 50, vec![]).expect("recipient call 3 commits");
+        assert_eq!(
+            r3.whisper, None,
+            "an unauthorized deposit never reaches the recipient"
+        );
+    }
 }

--- a/sdk/src/tool_gateway.rs
+++ b/sdk/src/tool_gateway.rs
@@ -359,14 +359,30 @@ pub struct WhisperFrame {
 }
 
 impl WhisperFrame {
-    /// Build a frame, enforcing the channel budgets: newlines collapse to
-    /// `"; "`, and the text is clipped to [`WHISPER_MAX_BYTES`] on a UTF-8
-    /// codepoint boundary. An all-whitespace text yields `None` — an empty
-    /// whisper is not a whisper.
+    /// Build a frame, enforcing the channel budgets: every line/paragraph break
+    /// (`\n`, `\r`, U+2028, U+2029, U+0085) collapses to `"; "`, all C0/C1 control
+    /// characters (ESC and friends — `char::is_control`, tab excepted) are
+    /// stripped, and the text is clipped to [`WHISPER_MAX_BYTES`] on a UTF-8
+    /// codepoint boundary. An all-whitespace/all-control text yields `None`.
+    ///
+    /// Stripping controls at intake is the fail-closed answer to the whisper being
+    /// an unauthenticated 200-byte string delivered on the TRUSTED gate return: a
+    /// frame cannot carry an ANSI escape or a Unicode line separator that reshapes
+    /// the surface (editor / agent transcript) it is rendered into. (Zero-width /
+    /// bidi FORMAT chars — category Cf — are NOT stripped here: that needs a
+    /// unicode-properties table this crate does not pull in; the consuming surface
+    /// should neutralize confusables. The structural break/escape vectors are what
+    /// this closes.)
     pub fn new(text: &str, from: Option<CellId>, seq: u64) -> Option<WhisperFrame> {
+        let is_break = |c: char| matches!(c, '\n' | '\r' | '\u{2028}' | '\u{2029}' | '\u{0085}');
         let joined = text
-            .split('\n')
-            .map(str::trim)
+            .split(is_break)
+            .map(|seg| {
+                seg.chars()
+                    .filter(|c| *c == '\t' || !c.is_control())
+                    .collect::<String>()
+            })
+            .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
             .collect::<Vec<_>>()
             .join("; ");
@@ -886,18 +902,57 @@ impl ToolGateway {
 
     /// Install THE CONTEXT CHANNEL's deposit source. The gateway drains at most
     /// one frame per ADMITTED call and rides it on the receipt
-    /// ([`ToolReceipt::whisper`]). The source must be non-blocking (a RAM read);
-    /// budgets are re-enforced at intake regardless of what it yields.
-    /// Un-installed (the default), every receipt carries `whisper: None`.
+    /// ([`ToolReceipt::whisper`]). Budgets are re-enforced at intake regardless of
+    /// what the source yields, and a source PANIC is caught and drops the whisper
+    /// (see [`next_whisper`](Self::next_whisper)). Un-installed (the default),
+    /// every receipt carries `whisper: None`.
+    ///
+    /// # Source contract (two caveats the gateway cannot enforce for you)
+    ///
+    /// * **Non-blocking.** The source is called on the drain that runs between a
+    ///   committed turn and the caller's receipt. A source that BLOCKS (contended
+    ///   lock, I/O, spin) delays the caller — and where the caller derives `now`
+    ///   from a wall clock, a delayed *next* call can cross `grant.deadline` and be
+    ///   refused. Make it a RAM read. Panics are caught; blocking is not.
+    /// * **Not on a confined-body gateway.** The grain-jail path
+    ///   (`deos-hermes::confined_body`) drains the frame onto the gateway's
+    ///   `PermissionOutcome` but its `Verdict` shape does not carry it onward, so a
+    ///   source installed there is consumed-but-never-delivered. Install sources
+    ///   only on gateways whose `PermissionOutcome`/`ToolReceipt` reaches the agent
+    ///   (the inline / ACP-wire paths) until `Verdict` carries the frame.
     pub fn set_whisper_source(&mut self, source: WhisperSource) {
         self.whisper_source = Some(source);
     }
 
     /// Drain one whisper frame for an admitted call, fail-closed: no source, a
-    /// source with nothing, or an over-budget frame that clips to empty all
-    /// yield `None`. Never touches admission state.
+    /// source with nothing, an over-budget frame that clips to empty, OR a source
+    /// that PANICS all yield `None`. Never touches admission state.
+    ///
+    /// The panic guard is load-bearing for the "purely additive" claim. The drain
+    /// runs AFTER the metered turn has committed (the counter advanced, the charge
+    /// moved value) but BEFORE the caller receives its `ToolReceipt` — on the
+    /// routed path, before the promise resolves. An unguarded panic in the
+    /// arbitrary [`WhisperSource`] closure would unwind through `invoke` /
+    /// `drive_executor` and DESTROY the receipt of a call that already committed
+    /// and was already paid for (worst case: the routed promise stuck `Pending`
+    /// forever). `catch_unwind` turns a source panic into a dropped whisper — the
+    /// whole point of the channel being additive — and disables the poisoned
+    /// source so it cannot panic again. It does NOT tame a source that BLOCKS;
+    /// that stays the documented non-blocking contract on [`set_whisper_source`].
     fn next_whisper(&mut self) -> Option<WhisperFrame> {
-        let frame = self.whisper_source.as_mut().and_then(|s| s())?;
+        let source = self.whisper_source.as_mut()?;
+        let drained =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| source()));
+        let frame = match drained {
+            Ok(Some(frame)) => frame,
+            Ok(None) => return None,
+            Err(_) => {
+                // The source panicked mid-drain: drop it so a repeat call cannot
+                // unwind the next committed turn's receipt, and yield no whisper.
+                self.whisper_source = None;
+                return None;
+            }
+        };
         // Re-enforce the channel budgets at intake — the source is not trusted
         // to have clipped (WhisperFrame::new is the only way to build a frame,
         // but a stored frame's text could have been mutated since).
@@ -1665,6 +1720,42 @@ mod tests {
 
         // An all-whitespace whisper is not a whisper.
         assert!(WhisperFrame::new("  \n  ", None, 3).is_none());
+
+        // Structure-forging chars are neutralized at intake: CR / U+2028 / U+2029 /
+        // U+0085 collapse like `\n`, and C0/C1 controls (here ESC) are stripped —
+        // so a frame cannot carry an ANSI escape or a Unicode line separator.
+        let hostile = "ok\r\u{2028}\u{2029}\u{0085}fake\u{1b}[2J line";
+        let f = WhisperFrame::new(hostile, None, 4).expect("frame after scrub");
+        assert!(
+            !f.text.chars().any(|c| c.is_control() && c != '\t'),
+            "no C0/C1 control survives intake: {:?}",
+            f.text
+        );
+        assert!(!f.text.contains('\u{2028}') && !f.text.contains('\u{2029}'));
+        assert_eq!(f.text, "ok; fake[2J line", "breaks collapse, ESC stripped");
+
+        // A text that is ONLY controls/separators is empty after scrub → None.
+        assert!(WhisperFrame::new("\u{1b}\r\u{2028}", None, 5).is_none());
+    }
+
+    #[test]
+    fn whisper_source_panic_is_caught_and_never_unwinds_a_committed_call() {
+        let (rt, root) = fresh_epoch();
+        let mut gw = ToolGateway::admit(&rt, &root, seeded_grant()).expect("admit");
+
+        // A source that PANICS on drain must not take down the receipt of a call
+        // that already committed + metered — the drain runs post-commit, so an
+        // unwind would vaporize a paid-for receipt (worst case on the routed path,
+        // a promise stuck Pending forever). catch_unwind turns it into no whisper.
+        gw.set_whisper_source(Box::new(|| panic!("hostile source")));
+        let r1 = gw.invoke(77, 50, vec![]).expect("committed despite a panicking source");
+        assert_eq!(r1.whisper, None, "panic => dropped whisper, not a lost receipt");
+        assert_eq!(r1.calls_made, 1, "metering unaffected by the source panic");
+
+        // The poisoned source was dropped, so the next call is clean (no re-panic).
+        let r2 = gw.invoke(77, 50, vec![]).expect("next call still commits");
+        assert_eq!(r2.whisper, None);
+        assert_eq!(r2.calls_made, 2);
     }
 
     #[test]

--- a/sdk/src/tool_gateway.rs
+++ b/sdk/src/tool_gateway.rs
@@ -326,6 +326,70 @@ impl std::fmt::Display for GatewayRefusal {
 
 impl std::error::Error for GatewayRefusal {}
 
+/// Byte budget for a [`WhisperFrame`]'s text — one line an agent reads in one
+/// saccade (~50 tokens). Enforced at frame intake ([`WhisperFrame::new`] clips
+/// on a codepoint boundary), so no oversized frame can ride a gate return.
+pub const WHISPER_MAX_BYTES: usize = 200;
+
+/// **THE CONTEXT CHANNEL** — a bounded, single-line contextual frame riding an
+/// ADMITTED gate return (`ToolReceipt::whisper`). The gate fires on every tool
+/// call of a mandated inhabitant; this is the one moment the driving loop is
+/// already reading a value from the gateway, so a whisper delivered here reaches
+/// the agent *between tool calls* at zero additional round-trips.
+///
+/// Contract (all fail-closed toward the caller):
+/// * absence is the normal case — `None` on the receipt means "no context";
+/// * never participates in admission — [`deleg_admit`] and the budget/charge
+///   legs are computed exactly as without a whisper, and a refused call carries
+///   no whisper (refusals stay minimal);
+/// * bounded — text is clipped to [`WHISPER_MAX_BYTES`] on a codepoint boundary
+///   and newlines collapse, at intake, so no source can exceed the budget;
+/// * not attested (this slice) — the frame rides the RETURN VALUE, not the
+///   committed turn, so the Lean-mirrored admission crown is untouched. Binding
+///   `hash(text)` into the metered turn (receipt-backed whisper provenance) is
+///   deliberate future work.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WhisperFrame {
+    /// The one line (≤ [`WHISPER_MAX_BYTES`] bytes, no `'\n'`).
+    pub text: String,
+    /// The writer's cell, when the deposit path knows it (attribution).
+    pub from: Option<CellId>,
+    /// Writer-side sequence number (dedup / audit).
+    pub seq: u64,
+}
+
+impl WhisperFrame {
+    /// Build a frame, enforcing the channel budgets: newlines collapse to
+    /// `"; "`, and the text is clipped to [`WHISPER_MAX_BYTES`] on a UTF-8
+    /// codepoint boundary. An all-whitespace text yields `None` — an empty
+    /// whisper is not a whisper.
+    pub fn new(text: &str, from: Option<CellId>, seq: u64) -> Option<WhisperFrame> {
+        let joined = text
+            .split('\n')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+            .join("; ");
+        if joined.is_empty() {
+            return None;
+        }
+        let mut end = joined.len().min(WHISPER_MAX_BYTES);
+        while end > 0 && !joined.is_char_boundary(end) {
+            end -= 1;
+        }
+        (end > 0).then(|| WhisperFrame {
+            text: joined[..end].to_string(),
+            from,
+            seq,
+        })
+    }
+}
+
+/// A pluggable whisper deposit source the gateway drains one frame from per
+/// ADMITTED call. Must be non-blocking (a RAM read — the gate's latency budget
+/// is sacred); a source that has nothing returns `None`.
+pub type WhisperSource = Box<dyn FnMut() -> Option<WhisperFrame> + Send>;
+
 /// The outcome of an admitted, committed tool invocation: the executor receipt
 /// proving the metered turn committed, plus the new counter value.
 #[derive(Clone, Debug)]
@@ -341,6 +405,10 @@ pub struct ToolReceipt {
     /// the metered turn, so the receipt witnesses the payment as well as the
     /// authorization — the "charge recorded in the verdict".
     pub paid: u64,
+    /// THE CONTEXT CHANNEL — at most one bounded [`WhisperFrame`] riding this
+    /// admitted return (`None` = no context pending; the overwhelmingly common
+    /// case, and always the case when no [`WhisperSource`] is installed).
+    pub whisper: Option<WhisperFrame>,
 }
 
 /// A custody-receipt-shaped DELIVERY WITNESS: proof that a routed tool-call's
@@ -509,6 +577,10 @@ pub struct ToolGateway {
     /// the caller's [`ToolGateway::resolve`]. A delivered route lands an
     /// `Ok(RoutedResult)`; a broken route lands an `Err(reason)`.
     results: std::collections::HashMap<[u8; 32], Result<RoutedResult, String>>,
+    /// THE CONTEXT CHANNEL's deposit seam: an optional [`WhisperSource`] the
+    /// gateway drains ONE frame from per admitted call. `None` (the default)
+    /// means every receipt carries `whisper: None` — exactly today's behavior.
+    whisper_source: Option<WhisperSource>,
 }
 
 /// One admitted routed tool-call sitting on the gateway's inbox, awaiting the
@@ -656,6 +728,7 @@ impl ToolGateway {
             inbox: VecDeque::new(),
             pending: PendingTurnRegistry::new(),
             results: std::collections::HashMap::new(),
+            whisper_source: None,
         })
     }
 
@@ -708,6 +781,7 @@ impl ToolGateway {
             inbox: VecDeque::new(),
             pending: PendingTurnRegistry::new(),
             results: std::collections::HashMap::new(),
+            whisper_source: None,
         })
     }
 
@@ -808,6 +882,26 @@ impl ToolGateway {
         self.charge
             .as_ref()
             .map(|c| c.budget.saturating_sub(self.spent))
+    }
+
+    /// Install THE CONTEXT CHANNEL's deposit source. The gateway drains at most
+    /// one frame per ADMITTED call and rides it on the receipt
+    /// ([`ToolReceipt::whisper`]). The source must be non-blocking (a RAM read);
+    /// budgets are re-enforced at intake regardless of what it yields.
+    /// Un-installed (the default), every receipt carries `whisper: None`.
+    pub fn set_whisper_source(&mut self, source: WhisperSource) {
+        self.whisper_source = Some(source);
+    }
+
+    /// Drain one whisper frame for an admitted call, fail-closed: no source, a
+    /// source with nothing, or an over-budget frame that clips to empty all
+    /// yield `None`. Never touches admission state.
+    fn next_whisper(&mut self) -> Option<WhisperFrame> {
+        let frame = self.whisper_source.as_mut().and_then(|s| s())?;
+        // Re-enforce the channel budgets at intake — the source is not trusted
+        // to have clipped (WhisperFrame::new is the only way to build a frame,
+        // but a stored frame's text could have been mutated since).
+        WhisperFrame::new(&frame.text, frame.from, frame.seq)
     }
 
     /// The per-call price of a paid mandate (`0` for a free mandate).
@@ -955,6 +1049,9 @@ impl ToolGateway {
             calls_made: new,
             remaining: self.remaining(),
             paid,
+            // THE CONTEXT CHANNEL: drained only on a COMMITTED call (a refusal
+            // returned above, before any drain — refusals carry no whisper).
+            whisper: self.next_whisper(),
         })
     }
 
@@ -1106,11 +1203,16 @@ impl ToolGateway {
 
             match self.worker.execute_method(&self.grant.tool_method, effects) {
                 Ok(receipt) => {
+                    // THE CONTEXT CHANNEL rides the DRAIN (delivery time), the
+                    // routed twin of the inline population — same one-frame,
+                    // committed-calls-only discipline.
+                    let whisper = self.next_whisper();
                     let tool_receipt = ToolReceipt {
                         receipt,
                         calls_made: item.new_count,
                         remaining: self.grant.rate_limit - item.new_count,
                         paid: item.charged,
+                        whisper,
                     };
                     let delivery = DeliveryReceipt {
                         routed_hash: item.routed_hash,
@@ -1542,5 +1644,69 @@ mod tests {
             gw2.worker_for_test().cap_issuer(),
             "random admits must not collide on issuers"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // THE CONTEXT CHANNEL — whisper frames on admitted gate returns.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn whisper_frame_enforces_the_channel_budgets() {
+        // One line: newlines collapse.
+        let f = WhisperFrame::new("first\nsecond\n", None, 1).expect("non-empty frame");
+        assert_eq!(f.text, "first; second");
+
+        // Byte cap on a codepoint boundary: 199 ASCII bytes + one 3-byte
+        // codepoint must clip to 199 bytes, never split the codepoint.
+        let long = "x".repeat(199) + "€"; // 202 bytes total
+        let f = WhisperFrame::new(&long, None, 2).expect("clipped frame");
+        assert_eq!(f.text.len(), 199, "clip lands on the codepoint boundary");
+        assert!(f.text.chars().all(|c| c == 'x'));
+
+        // An all-whitespace whisper is not a whisper.
+        assert!(WhisperFrame::new("  \n  ", None, 3).is_none());
+    }
+
+    #[test]
+    fn whisper_rides_admitted_returns_only_and_never_couples_to_admission() {
+        let (rt, root) = fresh_epoch();
+        let mut gw = ToolGateway::admit(&rt, &root, seeded_grant()).expect("admit");
+
+        // No source installed (the default): receipts carry None — today's shape.
+        let r1 = gw.invoke(77, 50, vec![]).expect("call 1 commits");
+        assert_eq!(r1.whisper, None, "no source => no whisper, nothing else changes");
+
+        // Install a one-frame source; the next ADMITTED call carries the frame…
+        let mut frames = vec![WhisperFrame::new(
+            "teammate landed the schema change — rebase before writing",
+            None,
+            1,
+        )
+        .unwrap()]
+        .into_iter();
+        gw.set_whisper_source(Box::new(move || frames.next()));
+
+        // …but a REFUSED call carries nothing and must NOT drain the source
+        // (refusals stay minimal; the frame waits for a committed call).
+        let refused = gw.invoke(99, 50, vec![]);
+        assert!(
+            matches!(
+                refused,
+                Err(ToolCallError::Refused(GatewayRefusal::OutOfScope { .. }))
+            ),
+            "out-of-scope refusal is unchanged by the channel"
+        );
+
+        let r2 = gw.invoke(77, 50, vec![]).expect("call 2 commits");
+        assert_eq!(
+            r2.whisper.as_ref().map(|w| w.text.as_str()),
+            Some("teammate landed the schema change — rebase before writing"),
+            "the admitted call after the refusal carries the frame"
+        );
+        assert_eq!(r2.calls_made, 2, "metering unchanged by the whisper");
+
+        // Source drained: the next admitted call is back to None.
+        let r3 = gw.invoke(77, 50, vec![]).expect("call 3 commits");
+        assert_eq!(r3.whisper, None, "one frame delivered exactly once");
     }
 }

--- a/sdk/src/whisper_deposit.rs
+++ b/sdk/src/whisper_deposit.rs
@@ -1,0 +1,322 @@
+//! # THE WHISPER DEPOSIT — the native, cap-gated, APPLY-TIME deposit half of the
+//! context channel (the intra-turn cousin of [`dregg_turn::Effect::Notify`]).
+//!
+//! The [`crate::tool_gateway`] carrier ships a bounded [`WhisperFrame`] on an
+//! ADMITTED gate return ([`crate::tool_gateway::ToolReceipt::whisper`]) by draining
+//! ONE frame per admitted call from a pluggable
+//! [`WhisperSource`](crate::tool_gateway::WhisperSource). The carrier says nothing
+//! about WHERE a frame comes from — a host brings its own source (the meld tmpfs
+//! hook is one). This module is the NATIVE dregg deposit that replaces that
+//! tmpfs-file source: a WRITER's cap-gated turn deposits a cell-attributed frame,
+//! addressed to a recipient SEAT, readable at APPLY time by the recipient gateway.
+//!
+//! ## The deposit primitive, and why THIS shape (the reuse-vs-new decision)
+//!
+//! A whisper deposit must (1) be a real, cap-gated TURN (so only an authorized
+//! writer can whisper to a seat, and the executor — not an out-of-band check — is
+//! the gate), (2) land at APPLY time, not finality (the view-polling lesson of
+//! `TELEPATHY_DREGG_VERDICT.md`: whispers are apply-time-adjacent, like Notify),
+//! (3) be attributable to the writer's cell (`from`), and (4) NOT touch the
+//! Lean-mirrored admission crown or the effect grammar it proves.
+//!
+//! Three native candidates were weighed; this module reuses the cap-gated turn
+//! path rather than any of them, ON PURPOSE:
+//!
+//! * **Literal [`dregg_turn::Effect::Notify`]** — WRONG PAYLOAD + WRONG LIFECYCLE.
+//!   `Notify`'s payload is a `wake: Box<Turn>` that mints a nullifier-backed
+//!   promise-hole the recipient must later `React` to (one-shot spend). A whisper
+//!   carries 200 bytes of text, is read ONCE off a gate return, and is never
+//!   reacted to. Smuggling text through a wake-turn memo, then leaving an unspent
+//!   reactive hole (with a timeout) on the ledger for every ephemeral line, abuses
+//!   the primitive and leaves a durable artifact for a RAM-only channel.
+//! * **A new `Effect::WhisperDeposit` kernel variant** — CLEANEST IN THEORY, but it
+//!   touches the index-sensitive `postcard` effect codec, needs a `LinearityClass`,
+//!   executor dispatch, and (to stay honest) proof-machinery wiring — exactly the
+//!   "kernel-adjacent" cost the PR draft flags. It also hands a RAM-resident channel
+//!   a durable ledger half. That is a real escalation, justified only once the
+//!   channel needs TRUSTLESS routing (see "Honest boundary" below); it is not
+//!   needed for the deposit + drain this slice delivers.
+//! * **[`dregg_storage::CapInbox`]** — DEPRECATED, and a DURABLE `MerkleQueue`
+//!   (quota-bounded, per-message anti-spam deposit). A whisper is ephemeral,
+//!   RAM-only, and free; a durable deposit-charged mailbox contradicts every one
+//!   of the channel's physics budgets.
+//!
+//! What fits dregg's grain: the deposit IS a cap-gated turn through the SAME
+//! [`SubAgent::execute_method`] gate the gateway's worker rides. The capability is
+//! a SEAT-ADDRESSED method verb ([`whisper_method`]): a writer scoped to
+//! `whisper.<seat>` may deposit to `<seat>` and ONLY `<seat>` — the executor rejects
+//! a deposit under any other seat verb with `TokenInsufficientCapability` (the
+//! cap-gate biting, in-executor). The committed deposit turn is the APPLY-TIME
+//! event; on commit the attributed frame lands in the recipient's [`WhisperInbox`],
+//! whose [`WhisperInbox::source_for`] is exactly a [`WhisperSource`] the recipient
+//! gateway installs. Nothing here touches `deleg_admit`, the metering, or the
+//! effect grammar.
+//!
+//! ## Honest boundary (the tradeoff this slice DOES NOT close)
+//!
+//! The frame TEXT is not yet cryptographically bound into the committed turn — the
+//! deposit turn proves the writer holds the seat capability (attribution is real
+//! and executor-enforced), but the SDK stamps the frame into the inbox after that
+//! commit rather than the executor routing the bytes itself. That is the SAME
+//! "not attested (this slice)" residual the carrier already documents: binding
+//! `hash(text)` into the metered turn — or promoting the deposit to a native
+//! `Effect` the executor routes end-to-end — is the receipt-backed-provenance
+//! follow-up. For a same-runtime writer→gateway pair (the shape this slice
+//! targets, and the meld consumer's) the cap-gated commit + SDK stamp is the honest
+//! equivalent of the tmpfs source it replaces, with a REAL per-seat capability
+//! gate the tmpfs file never had.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+
+use dregg_cell::CellId;
+use dregg_cell::program::field_from_u64;
+use dregg_token::Attenuation;
+use dregg_turn::{Effect, TurnReceipt};
+
+use crate::cipherclerk::HeldToken;
+use crate::error::SdkError;
+use crate::runtime::{AgentRuntime, SubAgent};
+use crate::tool_gateway::{WhisperFrame, WhisperSource};
+
+/// The slot on a WRITER cell that holds its monotone whisper sequence counter.
+///
+/// Each committed deposit advances this slot `seq → seq+1`, giving the deposit a
+/// real (non-empty) state transition to commit and an on-ledger, apply-time
+/// ordering for the writer's frames. It is the writer's private counter — distinct
+/// from the gateway worker cell's [`crate::tool_gateway::CALLS_MADE_SLOT`], which
+/// lives on the RECIPIENT cell — so the two never alias.
+pub const WHISPER_SEQ_SLOT: u8 = 5;
+
+/// **The seat-addressed capability verb** — the cap-gate's namespace.
+///
+/// A writer authorized to whisper to `seat` holds a biscuit credential scoped to
+/// exactly this method (`whisper.<hex(seat)>`); the executor admits its deposit
+/// turn IFF the presented verb is covered, and rejects a deposit to any other seat
+/// with `TokenInsufficientCapability`. "Who may whisper to a seat" is therefore
+/// "who holds a biscuit for that seat's whisper verb" — a genuine per-seat
+/// capability, enforced in-executor, not a courtesy check.
+pub fn whisper_method(seat: CellId) -> String {
+    let mut verb = String::with_capacity(8 + 64);
+    verb.push_str("whisper.");
+    for b in seat.0 {
+        verb.push_str(&format!("{b:02x}"));
+    }
+    verb
+}
+
+/// **THE RAM-RESIDENT WHISPER MAILBOX** — per-seat pending frames, the deposit's
+/// landing zone and the drain [`WhisperSource`]'s backing store.
+///
+/// Cloneable and `Send` (an `Arc<Mutex<..>>` handle): a [`WhisperWriter`] deposits
+/// into it, and the recipient gateway installs a [`WhisperInbox::source_for`]
+/// closure that drains it. Frames are per-seat FIFO and CONSUME-ONCE (the drain
+/// `pop_front`s), matching the channel's consume-once physics; the gateway drains
+/// exactly one per admitted call, so the one-frame-per-boundary budget is the
+/// gate's, not the inbox's. Never hits disk (the RAM-only budget).
+#[derive(Clone, Default)]
+pub struct WhisperInbox {
+    seats: Arc<Mutex<HashMap<CellId, VecDeque<WhisperFrame>>>>,
+}
+
+impl WhisperInbox {
+    /// A fresh, empty mailbox.
+    pub fn new() -> WhisperInbox {
+        WhisperInbox {
+            seats: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Push a committed deposit's frame onto `seat`'s queue (writer-internal).
+    fn push(&self, seat: CellId, frame: WhisperFrame) {
+        let mut seats = self.seats.lock().unwrap_or_else(|e| e.into_inner());
+        seats.entry(seat).or_default().push_back(frame);
+    }
+
+    /// The number of pending (undrained) frames for `seat` — inspection / tests.
+    pub fn pending(&self, seat: CellId) -> usize {
+        let seats = self.seats.lock().unwrap_or_else(|e| e.into_inner());
+        seats.get(&seat).map_or(0, |q| q.len())
+    }
+
+    /// **A drain source for `seat`** — a [`WhisperSource`] the recipient gateway
+    /// installs via [`crate::tool_gateway::ToolGateway::set_whisper_source`].
+    ///
+    /// Each call pops the front pending frame for `seat` (consume-once, FIFO), or
+    /// `None` when the queue is empty — a non-blocking RAM read, exactly the source
+    /// contract the gateway's drain requires. The gateway re-enforces the frame
+    /// budgets at intake, so this source is never trusted to have clipped.
+    pub fn source_for(&self, seat: CellId) -> WhisperSource {
+        let seats = self.seats.clone();
+        Box::new(move || {
+            let mut seats = seats.lock().unwrap_or_else(|e| e.into_inner());
+            seats.get_mut(&seat).and_then(|q| q.pop_front())
+        })
+    }
+}
+
+/// Why a whisper deposit did not land.
+#[derive(Debug)]
+pub enum WhisperDepositError {
+    /// The text clipped to nothing at intake (all-whitespace / all-control) — no
+    /// frame, no turn, nothing deposited.
+    EmptyFrame,
+    /// The cap-gated deposit turn was REFUSED by the executor — the writer's
+    /// credential does not cover the target seat's whisper verb
+    /// (`TokenInsufficientCapability`), so the deposit is unauthorized. NO frame
+    /// lands in the recipient's inbox.
+    Refused(SdkError),
+}
+
+impl std::fmt::Display for WhisperDepositError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WhisperDepositError::EmptyFrame => {
+                write!(f, "whisper deposit: text clipped to empty, nothing deposited")
+            }
+            WhisperDepositError::Refused(e) => {
+                write!(f, "whisper deposit refused (unauthorized seat): {e}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for WhisperDepositError {}
+
+/// The witness of a COMMITTED whisper deposit: the deposit turn's receipt (proof
+/// the cap-gated apply-time deposit committed), the attributed frame, and the seat
+/// it was deposited to.
+#[derive(Clone, Debug)]
+pub struct WhisperDeposit {
+    /// The committed deposit turn's receipt — proof the writer's cap-gated turn
+    /// applied (the APPLY-TIME event the frame is bound to).
+    pub receipt: TurnReceipt,
+    /// The deposited frame, carrying `from = <writer cell>` (attribution).
+    pub frame: WhisperFrame,
+    /// The seat the frame was deposited to (the recipient gateway's worker cell).
+    pub seat: CellId,
+}
+
+/// **A CAP-GATED WHISPER WRITER** — a principal authorized to whisper to a seat.
+///
+/// Admit one with [`WhisperWriter::admit`]: the grantor delegates a biscuit scoped
+/// to exactly [`whisper_method`]`(seat)`, so this writer may deposit to `seat` and
+/// only `seat`. [`WhisperWriter::whisper`] deposits a bounded frame to its
+/// authorized seat via a cap-gated APPLY-TIME turn; the recipient gateway reads it
+/// off the next admitted call's [`crate::tool_gateway::ToolReceipt::whisper`].
+pub struct WhisperWriter {
+    /// The writer's cap-gated cell — its biscuit covers the seat's whisper verb.
+    writer: SubAgent,
+    /// The seat this writer is authorized to whisper to (the recipient's worker cell).
+    seat: CellId,
+    /// The shared mailbox the committed deposit lands in.
+    inbox: WhisperInbox,
+    /// The writer's monotone whisper sequence (advances on each committed deposit).
+    seq: u64,
+}
+
+impl WhisperWriter {
+    /// Admit a writer authorized to whisper to `seat`.
+    ///
+    /// The grantor (`runtime`, holding `parent_token`) delegates a freshly spawned
+    /// [`SubAgent`] scoped to exactly [`whisper_method`]`(seat)`. The writer's
+    /// biscuit credential is the executor-enforced cap: a deposit turn under any
+    /// other seat's whisper verb is rejected with `TokenInsufficientCapability`.
+    pub fn admit(
+        runtime: &AgentRuntime,
+        parent_token: &HeldToken,
+        seat: CellId,
+        inbox: WhisperInbox,
+    ) -> Result<WhisperWriter, SdkError> {
+        let method = whisper_method(seat);
+        let writer = runtime.spawn_sub_agent_scoped(
+            &Attenuation::default(),
+            parent_token,
+            &[method.as_str()],
+        )?;
+        Ok(WhisperWriter {
+            writer,
+            seat,
+            inbox,
+            seq: 0,
+        })
+    }
+
+    /// This writer's cell id — the `from` its deposited frames carry.
+    pub fn writer_cell(&self) -> CellId {
+        self.writer.cell_id()
+    }
+
+    /// The seat this writer is authorized to whisper to.
+    pub fn seat(&self) -> CellId {
+        self.seat
+    }
+
+    /// **Deposit a whisper to this writer's authorized seat** (the common path).
+    ///
+    /// Builds a bounded [`WhisperFrame`] (budgets enforced at intake — an empty
+    /// clip is [`WhisperDepositError::EmptyFrame`]), then runs the cap-gated
+    /// APPLY-TIME deposit turn. On commit the attributed frame lands in the
+    /// recipient's [`WhisperInbox`], to be read off the recipient gateway's next
+    /// admitted call.
+    pub fn whisper(&mut self, text: &str) -> Result<WhisperDeposit, WhisperDepositError> {
+        let seat = self.seat;
+        self.deposit(seat, text)
+    }
+
+    /// Deposit to an ARBITRARY target seat using this writer's credential.
+    ///
+    /// The one code path both [`whisper`](Self::whisper) and the cap-gate exercise
+    /// share: the executor admits the deposit IFF this writer's biscuit covers
+    /// [`whisper_method`]`(target)`. A `target` this writer is NOT authorized for
+    /// is refused ([`WhisperDepositError::Refused`]) — the cap-gate biting. Public
+    /// for genuine multi-seat writers and for exercising the refusal.
+    pub fn whisper_to(
+        &mut self,
+        target: CellId,
+        text: &str,
+    ) -> Result<WhisperDeposit, WhisperDepositError> {
+        self.deposit(target, text)
+    }
+
+    /// The cap-gated APPLY-TIME deposit — one path, the cap-gate the only variable.
+    fn deposit(
+        &mut self,
+        target: CellId,
+        text: &str,
+    ) -> Result<WhisperDeposit, WhisperDepositError> {
+        // Build the frame FIRST (budgets enforced at intake), attributed to this
+        // writer's cell. An empty clip deposits nothing (no turn spent).
+        let seq = self.seq + 1;
+        let frame = WhisperFrame::new(text, Some(self.writer.cell_id()), seq)
+            .ok_or(WhisperDepositError::EmptyFrame)?;
+
+        // THE CAP-GATE + APPLY-TIME EVENT: run the seat-addressed whisper turn
+        // through the SAME executor gate the gateway's worker rides. The turn
+        // advances the writer's own monotone whisper-seq slot (a real committing
+        // transition; the writer cell's default `CellProgram::None` admits the
+        // SetField). The executor admits this turn IFF the writer's biscuit covers
+        // `whisper_method(target)`; an unauthorized seat yields
+        // `TokenInsufficientCapability` (an Err), so NO frame lands.
+        let effects = vec![Effect::SetField {
+            cell: self.writer.cell_id(),
+            index: WHISPER_SEQ_SLOT as usize,
+            value: field_from_u64(seq),
+        }];
+        let receipt = self
+            .writer
+            .execute_method(&whisper_method(target), effects)
+            .map_err(WhisperDepositError::Refused)?;
+
+        // COMMITTED (apply-time): the attributed frame lands in the recipient's
+        // inbox. The writer's tracked seq advances in lock-step with the committed
+        // slot; a refused deposit returned above, so neither advances on refusal.
+        self.seq = seq;
+        self.inbox.push(target, frame.clone());
+        Ok(WhisperDeposit {
+            receipt,
+            frame,
+            seat: target,
+        })
+    }
+}


### PR DESCRIPTION
## What this adds

`ToolGateway::invoke` / the routed drain fire on every tool call of a mandated
inhabitant — the exact moment a driving loop (a hermes agent, a buildr-style loop, an
MCP host) is about to hand a result back to its model. This PR lets that return carry
**at most one bounded, single-line contextual frame** — a *whisper* — so an agent
team's coordination layer can reach an agent *between its tool calls* without a second
channel, a poll, or a joint turn:

- `sdk::tool_gateway::WhisperFrame` — ≤200 bytes, one line, budgets enforced at
  intake (`WhisperFrame::new` clips on a codepoint boundary, strips control chars incl.
  U+2028/U+2029; empty ⇒ `None`).
- `ToolReceipt.whisper: Option<WhisperFrame>` — populated on **committed** calls only,
  on both the inline and routed paths. Refusals carry nothing and never drain the
  source: the refusal surface stays minimal.
- `ToolGateway::set_whisper_source(Box<dyn FnMut() -> Option<WhisperFrame> + Send>)` —
  the deposit seam. Un-installed (the default), every receipt carries `None`:
  byte-identical behavior to today. The source closure is called under `catch_unwind`,
  so a panicking host source drops the whisper and disarms itself rather than poisoning
  a committed, paid-for receipt.
- The ACP face: `PermissionOutcome::Allow.whisper: Option<String>`
  (`serde(default, skip_serializing_if = none)` — absent on the wire for old nodes),
  flow-through in `bridge.rs`, `deosWhisper` on the ACP mapping.

Verified: `cargo test -p dregg-sdk --lib tool_gateway` → **8 passed, 0 failed** on
current `main` (cf84a9baa), including budget/refusal/exactly-once/panic-safety cases.

## What this deliberately does NOT do

- **Never couples to admission.** `deleg_admit`, the budget leg, and the charge leg are
  untouched; a whisper lookup failure yields `whisper: None` on an otherwise identical
  result. The Lean-mirrored decision vector
  (`tool_gateway_admit_mirrors_lean_delegadmit`) is unchanged.
- **Not attested (this slice).** The frame rides the *return value*, not the committed
  turn, so the proven admission crown is untouched. Binding `hash(text)` into the
  metered turn — receipt-backed whisper provenance — is a natural second slice once the
  channel shape settles.
- **No deposit mechanism included.** This PR adds the *carrier*; how a frame gets
  deposited for a recipient is the design conversation below, and the seam
  (`WhisperSource`) lets hosts bring their own until dregg grows a native one.

## The design conversation we want: the deposit mechanism

Two native candidates exist in dregg today; we implemented neither, on purpose, and
would rather build the one you'd merge:

**(a) An `Effect::Notify` variant** ("whisper deposit"): a writer's turn deposits a
frame into the recipient gateway's pending whispers, the way Notify deposits a
promise-hole at APPLY time. Pros: apply-time delivery (no finality lag — the exact
lesson of our two-agent view-polling probe), writer attribution comes free from the
turn's signature, and the deposit is receipted on the *writer's* side. Cons: touches
the effect grammar (kernel-adjacent), and a RAM-resident channel now has a durable half
— the deposit turn is on the ledger even though the frame itself should stay ephemeral
(is that a feature — auditability — or a leak of the channel's never-hits-disk
property?).

**(b) A designated cell slot** on the gateway's worker cell (like `calls_made`): a
writer runs a `SetField` on a "whisper board" slot; the gate's `next_whisper()` reads
and clears it. Pros: no new effect kind, pure existing machinery, trivially cap-gateable
(who may write the slot = who may whisper to this seat). Cons: one slot = one pending
frame (coalescing semantics live in the writer), field elements force text packing
games, and read-and-clear from the gate return path means the gate now *writes* on a
read — which we suspect you'd reject on principle.

Our read: (a) fits dregg's grain better (deposits are turns; the gate only ever reads),
but we defer to your sense of the effect-grammar cost. A third door — whispers stay
entirely host-side and dregg only standardizes the carrier (this PR as-is) — is also a
legitimate resting point.

## Why we built it

This is the one primitive our multi-agent metaharness (meld, riding dregg) needs that
dregg doesn't yet have: a contextual line delivered to an agent *between its tool
calls*. We proved the consumer end end-to-end this cycle — a verified turn committed by
one agent surfaced as a one-line whisper between two tool calls of a second agent's
live session, read as context (not dead bytes) — over a host-side `WhisperSource`. This
PR is the seam that lets that delivery become a first-class, standardized part of the
gate rather than a host-side bolt-on. Consumer design: `meld/docs/WHISPER_DESIGN.md` (in
our tree). Found and filed alongside this cycle's dead-symbol reports (#49/#50/#51),
all now resolved in your sweep-up — thanks for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
