### PR TITLE
fix(node): idempotent solo finalization — stop double-applying ingress-committed turns (nothing finalizes in solo)

### DIFF
--- a/cli/src/commands/turn.rs
+++ b/cli/src/commands/turn.rs
@@ -344,9 +344,25 @@ async fn status(
             let post = receipt["post_state"].as_str().unwrap_or("?");
             let chain_index = receipt["chain_index"].as_u64().unwrap_or(0);
 
+            // The receipt is an immutable commit-time snapshot: a promoted
+            // turn's `finality` stays "tentative" forever. Consensus finality
+            // is surfaced ALONGSIDE it from the node's durable commit log.
+            let consensus_final = receipt["consensus_final"].as_bool().unwrap_or(false);
+
             ctx.header("Turn Receipt");
             ctx.kv("Turn hash", &abbrev_hex(turn_hash, 8, 4));
             ctx.kv("Finality", finality);
+            ctx.kv(
+                "Consensus final",
+                if consensus_final {
+                    "yes (durable commit record)"
+                } else {
+                    "no (pending finalization)"
+                },
+            );
+            if let Some(h) = receipt["attested_height"].as_u64() {
+                ctx.kv("Attested height", &h.to_string());
+            }
             ctx.kv("Chain index", &chain_index.to_string());
             ctx.kv("Actions", &actions.to_string());
             ctx.kv("Computrons", &crate::output::format_number(computrons));
@@ -359,12 +375,44 @@ async fn status(
             }
         }
         None => {
-            ctx.warn(&format!(
-                "No receipt found for turn {}",
-                abbrev_hex(turn_id, 8, 4)
-            ));
-            ctx.info("  The turn may still be pending finalization, or the hash may be wrong.");
-            ctx.info("  Receipts appear after the commit path runs; try again shortly.");
+            // No receipt on the chain — but the durable commit log is the
+            // authority on consensus finality (the receipt-chain append can
+            // fail while the turn still finalized). Ask the node's
+            // turn-status surface before claiming "maybe pending".
+            let is_full_hash = needle.len() == 64 && needle.chars().all(|c| c.is_ascii_hexdigit());
+            let status = if is_full_hash {
+                get_json(cfg, &format!("/api/turn/{needle}/status"))
+                    .await
+                    .ok()
+            } else {
+                None
+            };
+            match status.filter(|st| st["consensus_final"].as_bool() == Some(true)) {
+                Some(st) => {
+                    ctx.header("Turn Status");
+                    ctx.kv("Turn hash", &abbrev_hex(turn_id, 8, 4));
+                    ctx.kv("Consensus final", "yes (durable commit record)");
+                    if let Some(h) = st["attested_height"].as_u64() {
+                        ctx.kv("Attested height", &h.to_string());
+                    }
+                    if let Some(rh) = st["receipt_hash"].as_str() {
+                        ctx.kv("Receipt hash", &abbrev_hex(rh, 8, 4));
+                    }
+                    ctx.info(
+                        "  Finalized through consensus; no receipt on this node's receipt chain.",
+                    );
+                }
+                None => {
+                    ctx.warn(&format!(
+                        "No receipt found for turn {}",
+                        abbrev_hex(turn_id, 8, 4)
+                    ));
+                    ctx.info(
+                        "  The turn may still be pending finalization, or the hash may be wrong.",
+                    );
+                    ctx.info("  Receipts appear after the commit path runs; try again shortly.");
+                }
+            }
         }
     }
 

--- a/node/src/api.rs
+++ b/node/src/api.rs
@@ -10139,7 +10139,12 @@ mod tests {
         );
 
         // ── REPLAY REFUSES: the exact accepted envelope, resubmitted, is
-        // rejected — its receipt-chain binding now points behind the head. ──
+        // rejected. The executor's exact-nonce admission gate refuses it first
+        // ("nonce replay: expected 1, got 0" — the cell's nonce advanced past
+        // the replayed turn); the receipt-chain binding ("receipt chain
+        // mismatch") is the later, second line of defense. Either refusal
+        // upholds the property under test: a committed envelope can never
+        // commit twice. ──
         let response = submit(envelope).await.expect("replay response");
         let bytes = response
             .into_body()
@@ -10149,7 +10154,11 @@ mod tests {
             .to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&bytes).expect("replay json");
         assert_eq!(json["accepted"], false, "replayed envelope must refuse");
-        assert_eq!(json["error"], serde_json::json!("receipt chain mismatch"));
+        let err = json["error"].as_str().unwrap_or_default();
+        assert!(
+            err.contains("nonce replay") || err.contains("receipt chain mismatch"),
+            "replay must refuse as a replay, got: {err}"
+        );
     }
 
     #[test]

--- a/node/src/api.rs
+++ b/node/src/api.rs
@@ -3188,6 +3188,28 @@ async fn post_submit_turn(
     let turn_hash_bytes = turn.hash();
     let turn_hash = hex_encode(&turn_hash_bytes);
 
+    // SOLO BACKPRESSURE — checked BEFORE the in-place apply: a solo commit
+    // must retain its promotion entry, and the retention map never evicts
+    // (an evicted entry's mutation is already in the live ledger — its later
+    // promotion would nonce-replay-reject and later roots would carry an
+    // undurable mutation). Full map = finalization is stalled; refuse now so
+    // no unretained authoritative mutation can exist.
+    if s.solo_consensus.as_ref().is_some_and(|sc| sc.is_solo) && s.ingress_commits_full() {
+        tracing::warn!(
+            retained = s.ingress_commits.len(),
+            "solo ingress refused: finalization backlog (promotion retention full)"
+        );
+        drop(s);
+        return Ok(Json(SubmitTurnResponse {
+            accepted: false,
+            turn_hash: None,
+            proof_status: ActivityProofStatus::NotCommitted,
+            has_witness: false,
+            witness_count: 0,
+            error: Some("finalization backlog: retry".to_string()),
+        }));
+    }
+
     // O(touched) atomic rollback: arm a per-turn undo journal instead of cloning
     // the whole O(cells) ledger. The executor mutates `s.ledger` IN PLACE below;
     // on the rare `append_receipt` failure the journal restores exactly the
@@ -3267,15 +3289,17 @@ async fn post_submit_turn(
             // SOLO: retain the execution result for finalization PROMOTION —
             // consumed by exact turn hash in `execute_finalized_turn` so the
             // finalized pass writes the attested root + durable record without
-            // re-executing (the double-apply bug).
+            // re-executing (the double-apply bug). `snapshot` binds the PREFIX
+            // through this turn (canonical root + touched post-cells) HERE,
+            // under the same exclusive write lock that applied it — promotion
+            // must not re-read the live ledger (prefix poisoning).
             if s.solo_consensus.as_ref().is_some_and(|sc| sc.is_solo) {
-                s.retain_ingress_commit(
-                    turn_hash_bytes,
-                    crate::state::IngressCommit {
-                        receipt: receipt.clone(),
-                        touched_cells: crate::blocklace_sync::touched_cell_ids(&ledger_delta),
-                    },
+                let ingress = crate::state::IngressCommit::snapshot(
+                    &s.ledger,
+                    receipt.clone(),
+                    crate::blocklace_sync::touched_cell_ids(&ledger_delta),
                 );
+                s.retain_ingress_commit(turn_hash_bytes, ingress);
             }
             crate::metrics::set_receipt_chain_length(s.cclerk.receipt_chain_length() as f64);
             let receipt_hash = receipt.receipt_hash();
@@ -3523,6 +3547,30 @@ async fn post_submit_signed_turn(
     }
 
     let is_solo = s.solo_consensus.as_ref().is_some_and(|sc| sc.is_solo);
+
+    // SOLO BACKPRESSURE — checked BEFORE the in-place apply: a solo commit
+    // must retain its promotion entry, and the retention map never evicts
+    // (an evicted entry's mutation is already in the live ledger). Full map =
+    // finalization is stalled; refuse now so no unretained authoritative
+    // mutation can exist.
+    if is_solo && s.ingress_commits_full() {
+        tracing::warn!(
+            retained = s.ingress_commits.len(),
+            "solo signed-turn ingress refused: finalization backlog (promotion retention full)"
+        );
+        drop(s);
+        return Ok(Json(SubmitSignedTurnResponse {
+            accepted: false,
+            turn_hash: Some(turn_hash),
+            signer: Some(signer),
+            action_count,
+            proof_status: ActivityProofStatus::NotCommitted,
+            has_witness: false,
+            witness_count: 0,
+            error: Some("finalization backlog: retry".to_string()),
+        }));
+    }
+
     // Is the acting cell the node OPERATOR's own default cell? Only then does the
     // node operator's cipherclerk chain (`s.cclerk`) authoritatively own the turn's
     // receipt chain. A FOREIGN client's turn is decoupled: its receipt chain is its
@@ -3692,15 +3740,18 @@ async fn post_submit_signed_turn(
             // `execute_finalized_turn` consumes this by EXACT turn hash and
             // writes the finalization artifacts (attested root, durable commit
             // record) without re-executing the turn, which the advanced nonce
-            // would reject as a replay (the double-apply bug).
+            // would reject as a replay (the double-apply bug). `snapshot`
+            // binds the PREFIX through this turn (canonical root + touched
+            // post-cells) HERE, under the same exclusive write lock that
+            // applied it — promotion must not re-read the live ledger
+            // (prefix poisoning).
             if is_solo {
-                s.retain_ingress_commit(
-                    turn_hash_bytes,
-                    crate::state::IngressCommit {
-                        receipt: receipt.clone(),
-                        touched_cells: crate::blocklace_sync::touched_cell_ids(&ledger_delta),
-                    },
+                let ingress = crate::state::IngressCommit::snapshot(
+                    &s.ledger,
+                    receipt.clone(),
+                    crate::blocklace_sync::touched_cell_ids(&ledger_delta),
                 );
+                s.retain_ingress_commit(turn_hash_bytes, ingress);
             }
             let receipt_hash = receipt.receipt_hash();
             let witness_outcome = match prepare_rotatable_turn(
@@ -7140,6 +7191,28 @@ async fn post_faucet(
     // finalization pass, so it provisions + commits authoritatively here.
     let is_solo = s.solo_consensus.as_ref().is_some_and(|sc| sc.is_solo);
 
+    // SOLO BACKPRESSURE — checked BEFORE any authoritative provisioning or the
+    // in-place apply: a solo faucet commit must retain its promotion entry,
+    // and the retention map never evicts (an evicted entry's mutation is
+    // already in the live ledger). Full map = finalization is stalled; refuse
+    // now so no unretained authoritative mutation can exist. (Zero-amount is
+    // a cell MATERIALIZATION with no consensus turn and no retention — not
+    // gated.)
+    if is_solo && req.amount > 0 && s.ingress_commits_full() {
+        tracing::warn!(
+            retained = s.ingress_commits.len(),
+            "solo faucet ingress refused: finalization backlog (promotion retention full)"
+        );
+        drop(s);
+        return Ok(Json(FaucetResponse {
+            success: false,
+            tx_hash: None,
+            turn_hash: None,
+            amount: 0,
+            error: Some("finalization backlog: retry".to_string()),
+        }));
+    }
+
     // Ensure the faucet cell exists (create on first use). Uses the genesis-
     // derived faucet key so this is the SAME cell genesis mints the supply into;
     // on a genesis node it already exists on every node. In multi-party mode this
@@ -7441,14 +7514,17 @@ async fn post_faucet(
             // hash. This is what covers the faucet WITHOUT nonce heuristics:
             // its receipt may legitimately be refused by the node chain, so a
             // receipt-chain lookup at finalization cannot identify it.
+            // `snapshot` binds the PREFIX through this turn (canonical root +
+            // touched post-cells) HERE, under the same exclusive write lock
+            // that applied it — promotion must not re-read the live ledger
+            // (prefix poisoning).
             if is_solo {
-                s.retain_ingress_commit(
-                    turn_hash_bytes,
-                    crate::state::IngressCommit {
-                        receipt: receipt.clone(),
-                        touched_cells: crate::blocklace_sync::touched_cell_ids(&ledger_delta),
-                    },
+                let ingress = crate::state::IngressCommit::snapshot(
+                    &s.ledger,
+                    receipt.clone(),
+                    crate::blocklace_sync::touched_cell_ids(&ledger_delta),
                 );
+                s.retain_ingress_commit(turn_hash_bytes, ingress);
             }
 
             // The faucet turn is a REAL committed turn: append its receipt to

--- a/node/src/api.rs
+++ b/node/src/api.rs
@@ -3209,7 +3209,11 @@ async fn post_submit_turn(
     );
 
     match exec_result {
-        dregg_turn::TurnResult::Committed { mut receipt, .. } => {
+        dregg_turn::TurnResult::Committed {
+            mut receipt,
+            ledger_delta,
+            ..
+        } => {
             crate::metrics::inc_turns_executed("committed");
             crate::metrics::record_turn_execution_duration(start.elapsed().as_secs_f64());
             crate::metrics::set_ledger_cell_count(s.ledger.len() as f64);
@@ -3260,6 +3264,19 @@ async fn post_submit_turn(
             // then drop the journal — the in-place commit stands.
             let pre_ledger = s.ledger.pre_turn_touched_ledger();
             s.ledger.commit_restore_point();
+            // SOLO: retain the execution result for finalization PROMOTION —
+            // consumed by exact turn hash in `execute_finalized_turn` so the
+            // finalized pass writes the attested root + durable record without
+            // re-executing (the double-apply bug).
+            if s.solo_consensus.as_ref().is_some_and(|sc| sc.is_solo) {
+                s.retain_ingress_commit(
+                    turn_hash_bytes,
+                    crate::state::IngressCommit {
+                        receipt: receipt.clone(),
+                        touched_cells: crate::blocklace_sync::touched_cell_ids(&ledger_delta),
+                    },
+                );
+            }
             crate::metrics::set_receipt_chain_length(s.cclerk.receipt_chain_length() as f64);
             let receipt_hash = receipt.receipt_hash();
             // Gather the rotated attestation material from the REAL before/after
@@ -3611,7 +3628,11 @@ async fn post_submit_signed_turn(
     }
 
     match exec_result {
-        dregg_turn::TurnResult::Committed { mut receipt, .. } => {
+        dregg_turn::TurnResult::Committed {
+            mut receipt,
+            ledger_delta,
+            ..
+        } => {
             crate::metrics::inc_turns_executed("committed");
             crate::metrics::record_turn_execution_duration(start.elapsed().as_secs_f64());
             crate::metrics::set_ledger_cell_count(s.ledger.len() as f64);
@@ -3667,6 +3688,20 @@ async fn post_submit_signed_turn(
             // SOLO success: keep the in-place commit, drop the journal. (No-op
             // under MULTI-PARTY, already resolved to untouched above.)
             s.ledger.commit_restore_point();
+            // SOLO: retain the execution result for finalization PROMOTION —
+            // `execute_finalized_turn` consumes this by EXACT turn hash and
+            // writes the finalization artifacts (attested root, durable commit
+            // record) without re-executing the turn, which the advanced nonce
+            // would reject as a replay (the double-apply bug).
+            if is_solo {
+                s.retain_ingress_commit(
+                    turn_hash_bytes,
+                    crate::state::IngressCommit {
+                        receipt: receipt.clone(),
+                        touched_cells: crate::blocklace_sync::touched_cell_ids(&ledger_delta),
+                    },
+                );
+            }
             let receipt_hash = receipt.receipt_hash();
             let witness_outcome = match prepare_rotatable_turn(
                 &signed.turn,
@@ -7357,7 +7392,11 @@ async fn post_faucet(
     }
 
     match exec_result {
-        dregg_turn::TurnResult::Committed { mut receipt, .. } => {
+        dregg_turn::TurnResult::Committed {
+            mut receipt,
+            ledger_delta,
+            ..
+        } => {
             crate::metrics::set_ledger_cell_count(s.ledger.len() as f64);
 
             // Solo mode: tentative finality + height advance, exactly like the
@@ -7377,6 +7416,22 @@ async fn post_faucet(
                 solo.advance_height();
                 #[cfg(debug_assertions)]
                 debug_assert_signed_last(&receipt, &node_signing_key);
+            }
+
+            // SOLO: the faucet's in-place commit stands (committed above)
+            // whatever the receipt-chain append below decides — so retain the
+            // execution result for finalization PROMOTION, keyed by exact turn
+            // hash. This is what covers the faucet WITHOUT nonce heuristics:
+            // its receipt may legitimately be refused by the node chain, so a
+            // receipt-chain lookup at finalization cannot identify it.
+            if is_solo {
+                s.retain_ingress_commit(
+                    turn_hash_bytes,
+                    crate::state::IngressCommit {
+                        receipt: receipt.clone(),
+                        touched_cells: crate::blocklace_sync::touched_cell_ids(&ledger_delta),
+                    },
+                );
             }
 
             // The faucet turn is a REAL committed turn: append its receipt to

--- a/node/src/api.rs
+++ b/node/src/api.rs
@@ -7238,11 +7238,42 @@ async fn post_faucet(
     // `blake3(pubkey)`). Using the raw `s.federation_id` on an unconfigured solo
     // node mismatched the executor's domain and failed Ed25519 verification.
     let exec_federation_id = crate::executor_setup::federation_id_for_executor(&s);
-    let action = faucet_cclerk.make_action(
-        faucet_cell_id,
-        "faucet_transfer",
-        vec![transfer],
+    // NONCE BEFORE SIGNING — the `dregg-action-sig-v3` per-action signing
+    // message BINDS the submitting turn's nonce (`compute_signing_message`),
+    // and the verifier recomputes it with `turn.nonce`. `make_action` signs
+    // over the fresh per-request clerk's `next_turn_nonce()` (= 0, empty
+    // receipt chain), so every faucet turn AFTER the first carried a nonce the
+    // signature was not computed over and was rejected: "invalid
+    // authorization: hybrid: Ed25519 (classical) signature half failed". Sign
+    // explicitly over the nonce the turn will carry.
+    //
+    // SOLO: submission commits authoritatively under this same exclusive
+    // write lock, so the authoritative cell nonce is always current — use it
+    // directly. (The reservation would also poison solo permanently: it is
+    // bumped before execution, never rolled back on a failed turn, and solo's
+    // executor requires turn.nonce == cell nonce exactly.)
+    //
+    // FULL (pipelined): the authoritative nonce only advances at
+    // finalization, so a second submission before the first finalizes must
+    // reserve `max(authoritative, reserved)` and bump — back-to-back
+    // submissions get fresh consecutive nonces that finalize in order; `max`
+    // reconciles once in-flight turns finalize.
+    let authoritative_nonce = s
+        .ledger
+        .get(&faucet_cell_id)
+        .map(|c| c.state.nonce())
+        .unwrap_or(0);
+    let faucet_nonce = if is_solo {
+        authoritative_nonce
+    } else {
+        let n = authoritative_nonce.max(s.faucet_reserved_nonce.unwrap_or(0));
+        s.faucet_reserved_nonce = Some(n + 1);
+        n
+    };
+    let action = faucet_cclerk.sign_action_hybrid(
+        dregg_sdk::raw::unsigned_action_named(faucet_cell_id, "faucet_transfer", vec![transfer]),
         &exec_federation_id,
+        faucet_nonce,
     );
     let mut call_forest = CallForest::new();
     call_forest.add_root(action);
@@ -7251,22 +7282,8 @@ async fn post_faucet(
     // reject ("budget exceeded: limit=0, used=100"); the faucet cell holds the
     // genesis supply, so it covers a real fee. Size the fee to the estimated
     // cost so the gate passes deterministically.
-    // PIPELINED nonce: the faucet's AUTHORITATIVE nonce only advances when a
-    // faucet turn FINALIZES through consensus (the scratch-clone execution below
-    // deliberately does NOT mutate the authoritative ledger in full mode). Reading
-    // it directly meant a second faucet request submitted before the first
-    // finalized re-used the same nonce and replayed. Reserve the next nonce as
-    // `max(authoritative, reserved)` and bump the reservation, so back-to-back
-    // submissions get fresh consecutive nonces that finalize in order. `max`
-    // reconciles the two sides: once the in-flight turns finalize, the
-    // authoritative nonce catches up and no permanent gap opens.
-    let authoritative_nonce = s
-        .ledger
-        .get(&faucet_cell_id)
-        .map(|c| c.state.nonce())
-        .unwrap_or(0);
-    let faucet_nonce = authoritative_nonce.max(s.faucet_reserved_nonce.unwrap_or(0));
-    s.faucet_reserved_nonce = Some(faucet_nonce + 1);
+    // (Nonce computed above, before the action was signed — it is bound into
+    // the per-action signature.)
     // Receipt-chain head for the turn's verified ChainHead leg.
     //
     // SOLO (n=1): submission is authoritative, so bind to the local chain head
@@ -9808,6 +9825,76 @@ mod tests {
         let tx = compute_faucet_activity_hash(&dregg_cell::CellId([0xC0; 32]), 0);
         assert_eq!(tx.len(), 64);
         assert!(tx.chars().all(|ch| ch.is_ascii_hexdigit()));
+    }
+
+    /// Faucet nonce-binding regression: EVERY sequential funded grant must
+    /// commit, not just the first. The per-action `dregg-action-sig-v3`
+    /// signature binds the submitting turn's nonce; `post_faucet` signed over
+    /// the fresh per-request clerk's nonce (always 0) while the turn carried
+    /// the faucet cell's real nonce (>= 1 after the first grant), so grant 2+
+    /// failed "hybrid: Ed25519 (classical) signature half failed". Three
+    /// grants pin sign/carry nonce agreement at 0, 1 AND 2.
+    #[tokio::test]
+    async fn sequential_faucet_grants_all_commit() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = NodeState::new(tmp.path(), vec![]).expect("node state");
+        state.write().await.unlocked = true;
+        {
+            let mut s = state.write().await;
+            let sk = s.cclerk.gossip_signing_key().to_bytes();
+            s.solo_consensus = Some(dregg_federation::solo::SoloConsensusState::new(sk));
+        }
+        let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+        let app = router(state.clone(), true, recorder.handle());
+        let addr: std::net::SocketAddr = "127.0.0.1:4444".parse().unwrap();
+
+        for i in 0u8..3 {
+            let clerk = dregg_sdk::AgentCipherclerk::from_key_bytes(zeroize::Zeroizing::new(
+                *blake3::hash(&[b"seq-faucet".as_slice(), &[i]].concat()).as_bytes(),
+            ));
+            let default_token_id = *blake3::hash(b"default").as_bytes();
+            let cell = dregg_cell::CellId::derive_raw(&clerk.public_key().0, &default_token_id);
+            let body = serde_json::json!({
+                "recipient": hex_encode(&cell.0),
+                "amount": 5_000u64,
+                "public_key": hex_encode(&clerk.public_key().0),
+            });
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/api/faucet")
+                        .header("content-type", "application/json")
+                        .extension(ConnectInfo(addr))
+                        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                        .expect("faucet request"),
+                )
+                .await
+                .expect("faucet response");
+            assert_eq!(response.status(), StatusCode::OK);
+            let bytes = response
+                .into_body()
+                .collect()
+                .await
+                .expect("body")
+                .to_bytes();
+            let json: serde_json::Value = serde_json::from_slice(&bytes).expect("faucet json");
+            assert_eq!(
+                json["success"], true,
+                "sequential funded grant {i} must commit: {json}"
+            );
+            let s = state.read().await;
+            assert_eq!(
+                s.ledger
+                    .get(&dregg_cell::CellId(cell.0))
+                    .expect("recipient materialized")
+                    .state
+                    .balance(),
+                5_000,
+                "grant {i} funded its recipient"
+            );
+        }
     }
 
     /// #171 remote `.turn()` e2e through the HTTP router: a keypair the node

--- a/node/src/api.rs
+++ b/node/src/api.rs
@@ -233,6 +233,15 @@ pub struct ReceiptInfo {
     pub executor_signed: bool,
     pub has_witness: bool,
     pub witness_count: usize,
+    /// True when a durable finalized `CommitRecord` exists for this turn
+    /// (the commit log's turn-by-hash index). The receipt itself is an
+    /// IMMUTABLE snapshot signed at commit time — a solo/promoted turn's
+    /// receipt stays `finality: "tentative"` forever, so consensus finality
+    /// is surfaced ALONGSIDE it from the durable store, never by mutating it.
+    pub consensus_final: bool,
+    /// The attested height the turn finalized at (`CommitRecord::height`).
+    /// `None` until the turn is consensus-final.
+    pub attested_height: Option<u64>,
 }
 
 #[derive(Deserialize)]
@@ -1698,6 +1707,7 @@ pub fn router_with_cors(
             get(crate::identity_export::get_identity_export),
         )
         .route("/api/turn/{hash}/proof", get(get_turn_proof))
+        .route("/api/turn/{hash}/status", get(get_turn_status))
         .route("/api/starbridge/receipts", get(get_starbridge_receipts))
         .route("/api/starbridge/events", get(get_starbridge_events))
         .route("/api/starbridge/turns", get(get_starbridge_turns))
@@ -2485,6 +2495,40 @@ async fn get_turn_proof(
     }
 }
 
+/// `GET /api/turn/{hash}/status` — consensus-finality status for one turn,
+/// straight from the DURABLE store (the commit log's turn-by-hash index).
+///
+/// The receipt chain is an immutable tentative-at-commit snapshot: a promoted
+/// turn's receipt reports `finality: "tentative"` forever, and a turn whose
+/// receipt-chain append failed has NO receipt at all even though a durable
+/// `CommitRecord` proves it finalized. This surface answers "did consensus
+/// finalize this turn?" independently of the receipt chain; `receipt_present`
+/// says whether `/api/receipts` also carries it.
+async fn get_turn_status(
+    AxumPath(hash): AxumPath<String>,
+    State(state): State<NodeState>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let bytes = hex_decode(&hash).map_err(|_| StatusCode::BAD_REQUEST)?;
+    let turn_hash: [u8; 32] = bytes.try_into().map_err(|_| StatusCode::BAD_REQUEST)?;
+    let s = state.read().await;
+    let commit = s
+        .store
+        .lookup_turn(&turn_hash)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let receipt_present = s
+        .cclerk
+        .receipt_chain()
+        .iter()
+        .any(|r| r.turn_hash == turn_hash);
+    Ok(Json(serde_json::json!({
+        "turn_hash": hex_encode(&turn_hash),
+        "consensus_final": commit.is_some(),
+        "attested_height": commit.as_ref().map(|c| c.height),
+        "receipt_hash": commit.as_ref().map(|c| hex_encode(&c.receipt_hash)),
+        "receipt_present": receipt_present,
+    })))
+}
+
 async fn get_starbridge_receipts(
     Query(params): Query<StarbridgeQuery>,
     State(state): State<NodeState>,
@@ -2518,6 +2562,7 @@ async fn get_starbridge_receipts(
             let turn_hash_hex = hex_encode(&r.turn_hash);
             // Same attached-proof semantics as `receipt_infos_from_chain_with_witnesses`.
             let has_proof = witness_count > 0 || stored_full_turn_proof_exists(&s, &turn_hash_hex);
+            let attested_height = committed_turn_height(&s, &r.turn_hash);
             StarbridgeReceiptInfo {
                 receipt: ReceiptInfo {
                     chain_index: idx as u64,
@@ -2538,6 +2583,8 @@ async fn get_starbridge_receipts(
                     executor_signed: r.executor_signature.is_some(),
                     has_witness: witness_count > 0,
                     witness_count,
+                    consensus_final: attested_height.is_some(),
+                    attested_height,
                 },
                 effects_hash: hex_encode(&r.effects_hash),
                 federation_id: hex_encode(&r.federation_id),
@@ -2560,12 +2607,26 @@ fn stored_full_turn_proof_exists(s: &crate::state::NodeStateInner, turn_hash_hex
     matches!(s.store.get_config(&key), Ok(Some(_)))
 }
 
+/// The attested height of the durable finalized `CommitRecord` for a turn, if
+/// one exists (the commit log's turn-by-hash index). `None` = not (yet)
+/// consensus-final on this node — or a store read error, which is
+/// conservatively reported as not-final (the durable record is the ONLY
+/// evidence of consensus finality this surface will claim).
+fn committed_turn_height(s: &crate::state::NodeStateInner, turn_hash: &[u8; 32]) -> Option<u64> {
+    s.store
+        .lookup_turn(turn_hash)
+        .ok()
+        .flatten()
+        .map(|rec| rec.height)
+}
+
 fn receipt_infos_from_chain(s: &crate::state::NodeStateInner, limit: usize) -> Vec<ReceiptInfo> {
     receipt_infos_from_chain_with_witnesses(
         s.cclerk.receipt_chain(),
         limit,
         |hash| s.witnessed_receipt_count(hash),
         |turn_hash_hex| stored_full_turn_proof_exists(s, turn_hash_hex),
+        |turn_hash| committed_turn_height(s, turn_hash),
     )
 }
 
@@ -2574,6 +2635,7 @@ fn receipt_infos_from_chain_with_witnesses(
     limit: usize,
     witness_count_for: impl Fn(&[u8; 32]) -> usize,
     stored_proof_for: impl Fn(&str) -> bool,
+    attested_height_for: impl Fn(&[u8; 32]) -> Option<u64>,
 ) -> Vec<ReceiptInfo> {
     let chain_len = chain.len();
     chain
@@ -2594,6 +2656,7 @@ fn receipt_infos_from_chain_with_witnesses(
             // node configs that never set an executor signing key, even while
             // the pool was attaching real proofs.
             let has_proof = witness_count > 0 || stored_proof_for(&turn_hash_hex);
+            let attested_height = attested_height_for(&r.turn_hash);
             ReceiptInfo {
                 chain_index: idx as u64,
                 chain_head: idx + 1 == chain_len,
@@ -2613,6 +2676,8 @@ fn receipt_infos_from_chain_with_witnesses(
                 executor_signed: r.executor_signature.is_some(),
                 has_witness: witness_count > 0,
                 witness_count,
+                consensus_final: attested_height.is_some(),
+                attested_height,
             }
         })
         .collect()
@@ -7080,6 +7145,22 @@ impl FaucetRateLimiter {
     }
 }
 
+/// Serializes value-carrying faucet grants from nonce RESERVATION through
+/// blocklace SUBMISSION. The full-mode faucet reserves a consecutive nonce
+/// under the state write lock, but the blocklace submission used to run in a
+/// detached task — two concurrent grants could submit in REVERSED order, and
+/// since full-mode blocklace submission is an ordered FIFO
+/// (`pending_payloads.push_back`, drained in order into round blocks), the
+/// lower nonce finalizing after the higher one wedged the reservation floor
+/// (the executor's exact-nonce gate rejects the out-of-order turn forever).
+/// Acquired BEFORE the state write lock (so mutex order == reservation order)
+/// and held on the SAME request task until the blocklace submit returns —
+/// never awaited while the state lock is held, so no lock-order inversion.
+/// Process-wide rather than per-node (state.rs is owned elsewhere): with
+/// multiple in-process nodes this over-serializes across nodes, which only
+/// costs latency, never ordering.
+static FAUCET_SUBMIT_ORDER: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 /// POST /api/faucet — transfer computrons from the faucet cell to a recipient.
 ///
 /// Only enabled when `--enable-faucet` is set. Rate limited TWICE:
@@ -7172,6 +7253,16 @@ async fn post_faucet(
             error: Some("rate limited: 1 request per cell per minute".to_string()),
         }));
     }
+
+    // SUBMISSION ORDER (see `FAUCET_SUBMIT_ORDER`): value-carrying grants
+    // serialize reserve→submit so blocklace submissions land in reservation
+    // order. Zero-amount materialization neither reserves nor submits, so it
+    // skips the queue.
+    let _submit_order = if req.amount > 0 {
+        Some(FAUCET_SUBMIT_ORDER.lock().await)
+    } else {
+        None
+    };
 
     let mut s = state.write().await;
 
@@ -7614,11 +7705,15 @@ async fn post_faucet(
                         .await;
                 });
             }
+            // Blocklace submission runs INLINE on this request task, still
+            // under `_submit_order` — a detached task here let two concurrent
+            // grants submit in reversed reservation order and wedge the
+            // reservation floor (see `FAUCET_SUBMIT_ORDER`). The submit is a
+            // staging push (full mode: `pending_payloads.push_back` + notify;
+            // solo: local block production), NOT finality — the response still
+            // returns before the turn finalizes.
             if let Some(blocklace) = state.blocklace().await {
-                let state_for_blocklace = state.clone();
-                tokio::spawn(async move {
-                    blocklace.submit_turn(&state_for_blocklace, turn_data).await;
-                });
+                blocklace.submit_turn(&state, turn_data).await;
             }
 
             Ok(Json(FaucetResponse {
@@ -9071,7 +9166,7 @@ mod tests {
             });
         }
 
-        let infos = receipt_infos_from_chain_with_witnesses(&chain, 50, |_| 0, |_| false);
+        let infos = receipt_infos_from_chain_with_witnesses(&chain, 50, |_| 0, |_| false, |_| None);
         assert_eq!(infos.len(), 3);
         assert_eq!(infos[0].chain_index, 2);
         assert!(infos[0].chain_head);
@@ -9097,12 +9192,12 @@ mod tests {
         }];
 
         // No witness, no stored proof: honestly unproven.
-        let infos = receipt_infos_from_chain_with_witnesses(&chain, 50, |_| 0, |_| false);
+        let infos = receipt_infos_from_chain_with_witnesses(&chain, 50, |_| 0, |_| false, |_| None);
         assert!(!infos[0].has_proof);
         assert!(!infos[0].executor_signed);
 
         // The async prove pool attached a WitnessedReceipt: has_proof flips.
-        let infos = receipt_infos_from_chain_with_witnesses(&chain, 50, |_| 1, |_| false);
+        let infos = receipt_infos_from_chain_with_witnesses(&chain, 50, |_| 1, |_| false, |_| None);
         assert!(
             infos[0].has_proof,
             "a pool-attached WitnessedReceipt must flip has_proof even with no executor signature"
@@ -9114,11 +9209,153 @@ mod tests {
             50,
             |_| 0,
             |th| th == hex_encode(&[0x42u8; 32]),
+            |_| None,
         );
         assert!(
             infos[0].has_proof,
             "a persisted full-turn proof must flip has_proof"
         );
+    }
+
+    /// Consensus finality on the receipts surface comes from the DURABLE
+    /// commit log (turn-by-hash index), never from the immutable receipt: a
+    /// promoted turn's receipt stays `finality: "tentative"` forever, so the
+    /// certificate is surfaced ALONGSIDE it as `consensus_final` +
+    /// `attested_height`.
+    #[test]
+    fn receipt_consensus_finality_comes_from_durable_commit_log() {
+        let store = dregg_persist::PersistentStore::open_in_memory().expect("store");
+        let final_hash = [0x11u8; 32];
+        let record = dregg_persist::CommitRecord {
+            ordinal: 0,
+            height: 7,
+            block_id: [1u8; 32],
+            block_executed_up_to: 0,
+            turn_hash: final_hash,
+            creator: [0xA0u8; 32],
+            receipt_hash: [0x22u8; 32],
+            ledger_root: [0u8; 32],
+            touched_cells: vec![],
+        };
+        store.commit_finalized_turn(0, &record).expect("commit");
+
+        let chain = vec![
+            dregg_turn::TurnReceipt {
+                turn_hash: final_hash,
+                agent: CellId([0xA0; 32]),
+                finality: dregg_turn::Finality::Tentative,
+                ..Default::default()
+            },
+            dregg_turn::TurnReceipt {
+                turn_hash: [0x33; 32],
+                agent: CellId([0xA0; 32]),
+                finality: dregg_turn::Finality::Tentative,
+                ..Default::default()
+            },
+        ];
+        let infos = receipt_infos_from_chain_with_witnesses(
+            &chain,
+            50,
+            |_| 0,
+            |_| false,
+            |th| store.lookup_turn(th).ok().flatten().map(|r| r.height),
+        );
+
+        // Listing is reverse chain order: infos[0] is the NOT-finalized turn.
+        assert!(!infos[0].consensus_final);
+        assert_eq!(infos[0].attested_height, None);
+        assert!(
+            infos[1].consensus_final,
+            "a durable CommitRecord must surface as consensus_final"
+        );
+        assert_eq!(infos[1].attested_height, Some(7));
+        assert_eq!(
+            infos[1].finality, "tentative",
+            "the immutable receipt snapshot must stay untouched"
+        );
+
+        // Response shape: the JSON carries the new fields.
+        let v = serde_json::to_value(&infos[1]).expect("serialize");
+        assert_eq!(v["consensus_final"], serde_json::json!(true));
+        assert_eq!(v["attested_height"], serde_json::json!(7));
+        let v = serde_json::to_value(&infos[0]).expect("serialize");
+        assert_eq!(v["consensus_final"], serde_json::json!(false));
+        assert_eq!(v["attested_height"], serde_json::Value::Null);
+    }
+
+    /// `GET /api/turn/{hash}/status` answers from the durable store even when
+    /// the receipt chain never got the receipt (the append-failed case): the
+    /// turn is reported consensus-final with `receipt_present: false`, and an
+    /// unknown turn is honestly not final.
+    #[tokio::test]
+    async fn turn_status_endpoint_reports_durable_consensus_finality() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = NodeState::new(tmp.path(), vec![]).expect("node state");
+        let turn_hash = [0x5Au8; 32];
+        {
+            let s = state.write().await;
+            let record = dregg_persist::CommitRecord {
+                ordinal: 0,
+                height: 3,
+                block_id: [1u8; 32],
+                block_executed_up_to: 0,
+                turn_hash,
+                creator: [2u8; 32],
+                receipt_hash: [3u8; 32],
+                ledger_root: [0u8; 32],
+                touched_cells: vec![],
+            };
+            s.store.commit_finalized_turn(0, &record).expect("commit");
+        }
+        let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+        let app = router(state, false, recorder.handle());
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/turn/{}/status", hex_encode(&turn_hash)))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("body")
+            .to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("json");
+        assert_eq!(json["consensus_final"], serde_json::json!(true));
+        assert_eq!(json["attested_height"], serde_json::json!(3));
+        assert_eq!(json["receipt_present"], serde_json::json!(false));
+        assert_eq!(
+            json["receipt_hash"],
+            serde_json::json!(hex_encode(&[3u8; 32]))
+        );
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/turn/{}/status", hex_encode(&[0u8; 32])))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("body")
+            .to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("json");
+        assert_eq!(json["consensus_final"], serde_json::json!(false));
+        assert_eq!(json["attested_height"], serde_json::Value::Null);
     }
 
     #[tokio::test]
@@ -10080,13 +10317,12 @@ mod tests {
         };
         // Bound to the turn nonce below (`nonce: 0` — the faucet-born agent
         // cell's first turn): dregg-action-sig-v3 binds the submitting turn's
-        // nonce into the signature.
-        let message = dregg_turn::TurnExecutor::compute_signing_message(&unsigned, &fed_id, 0);
-        let sig = clerk.sign_bytes(&message);
-        let action = Action {
-            authorization: Authorization::from_sig_bytes(sig.0),
-            ..unsigned
-        };
+        // nonce into the signature. Signed HYBRID (ed25519 + ML-DSA) — the
+        // deployed admission posture is `require_pq = ON`, and a real
+        // `RemoteRuntime` client emits the hybrid credential; a classical-only
+        // authorization refuses at the PQ admission gate before the replay leg
+        // ever runs.
+        let action = clerk.sign_action_hybrid(unsigned, &fed_id, 0);
         let mut forest = CallForest::new();
         forest.add_root(action);
 

--- a/node/src/blocklace_sync.rs
+++ b/node/src/blocklace_sync.rs
@@ -4329,6 +4329,44 @@ async fn execute_finalized_turn(
 
     // Execute the turn against the local ledger.
     let mut s = state.write().await;
+
+    // IDEMPOTENT FINALIZATION — solo double-apply fix.
+    //
+    // In SOLO mode the `/turns/submit` ingress path already applied this turn
+    // AUTHORITATIVELY: it kept the in-place ledger commit (`if !is_solo { rollback }`
+    // in api.rs is false for solo) AND appended the turn's receipt to the node
+    // chain (`if is_operator_agent || is_solo { append_receipt }`). Re-executing the
+    // same turn HERE double-applies it: the acting cell's nonce is already advanced
+    // past the turn's nonce, so the executor's admission prologue rejects it as
+    // `nonce replay: expected N, got N-1`. The stale premise this path was written
+    // against — "SOLO (n=1) has no finalization pass" (api.rs) — is no longer true:
+    // solo runs the blocklace and trivially finalizes every block, so EVERY solo
+    // turn hit this and finalization never accepted one (observed devnet:
+    // executed=0, rejected=N; the turns stayed tentative).
+    //
+    // Fix: if this exact turn (by hash) is already in the node's receipt chain AND
+    // we are solo, ingress already committed it authoritatively — treat finalization
+    // as idempotent-already-applied and skip re-execution. Scoped to solo so the
+    // multi-party paths are untouched: a foreign client's turn is NOT in the local
+    // chain here (ingress rolled back and did not append), and the operator's own
+    // multi-party turn rolled its ledger back (nonce NOT advanced), so both still
+    // execute normally below.
+    let is_solo = s.solo_consensus.as_ref().is_some_and(|sc| sc.is_solo);
+    if is_solo
+        && s.cclerk
+            .receipt_chain()
+            .iter()
+            .any(|r| r.turn_hash == computed_hash)
+    {
+        debug!(
+            turn_hash = %turn_hash_hex,
+            block_id = %block_id,
+            "finalized turn already applied by solo ingress (authoritative in-place commit); \
+             skipping re-execution to avoid double-apply nonce replay (idempotent finalization)"
+        );
+        return;
+    }
+
     let mut executor = dregg_turn::TurnExecutor::new(dregg_turn::ComputronCosts::default());
 
     crate::executor_setup::configure_turn_executor(

--- a/node/src/blocklace_sync.rs
+++ b/node/src/blocklace_sync.rs
@@ -4349,13 +4349,19 @@ async fn execute_finalized_turn(
     //  * exact-hash + retained result, not nonce heuristics — a conflicting
     //    foreign turn at the same nonce hashes differently, MISSES the cache,
     //    executes below, and is correctly rejected as a replay;
-    //  * no federation-mode check HERE — insertion is what is solo-gated, so the
-    //    cache only ever holds turns THIS node ingress-committed; a stale solo
-    //    flag after a live membership change can neither admit a foreign block's
-    //    turn nor skip a local one;
-    //  * consume-once (`remove`) — a re-delivered block re-executes and the
-    //    executor's own replay rejection stands.
-    if let Some(ingress) = s.ingress_commits.remove(&computed_hash) {
+    //  * no federation-mode check HERE — insertion is what is solo-gated (and a
+    //    live solo→multi transition drains the cache atomically with the mode
+    //    flip, see `apply_passed_proposal`), so the cache only ever holds turns
+    //    THIS node ingress-committed; a stale solo flag after a live membership
+    //    change can neither admit a foreign block's turn nor skip a local one;
+    //  * consume-ON-SUCCESS (`get`+clone here; `promote_ingress_committed_turn`
+    //    removes the entry only after the durable commit record lands) — a
+    //    failed durable write keeps the entry so a re-delivered/retried
+    //    finalized block retries promotion idempotently (the durable
+    //    turn-by-hash index guards double-promotion); after a SUCCESSFUL
+    //    promotion the entry is gone, so a re-delivered block re-executes and
+    //    the executor's own replay rejection stands.
+    if let Some(ingress) = s.ingress_commits.get(&computed_hash).cloned() {
         drop(s);
         promote_ingress_committed_turn(
             state,
@@ -5537,18 +5543,50 @@ async fn promote_ingress_committed_turn(
 ) {
     let mut s = state.write().await;
 
-    // Height/timestamp exactly as the executed path derives them: a configured
-    // executor's `block_height` (Next) and clock. Nothing is executed with it.
-    let mut height_exec = dregg_turn::TurnExecutor::new(dregg_turn::ComputronCosts::default());
-    crate::executor_setup::configure_turn_executor(
-        &mut height_exec,
-        &s,
-        crate::executor_setup::BlockHeightMode::Next,
-    );
-    let new_height = height_exec.block_height;
-    let now = height_exec.current_timestamp;
+    // DOUBLE-PROMOTION GUARD (consume-on-success): the retention entry is only
+    // removed after the durable commit record lands, so a block re-delivered
+    // while the entry survives (a prior durable-write failure, or a crash
+    // between the write and the remove) retries promotion. If the durable
+    // commit log ALREADY has this exact turn hash, the promotion happened —
+    // this delivery is a no-op that just consumes the entry. (Checking
+    // `commit_cursor` alone cannot identify WHICH turn landed; the
+    // turn-by-hash index can.)
+    if let Ok(Some(existing)) = s.store.lookup_turn(&computed_hash) {
+        let _ = s.ingress_commits.remove(&computed_hash);
+        info!(
+            turn_hash = %turn_hash_hex,
+            block_id = %block_id,
+            ordinal = existing.ordinal,
+            height = existing.height,
+            "finalized turn already durably promoted (turn-by-hash index hit); \
+             re-delivery is a no-op — retention entry consumed"
+        );
+        return;
+    }
 
-    let receipt = ingress.receipt;
+    // HEIGHT — the DURABLE truth: next attested height = latest durably
+    // attested root height (else 0) + 1. Deliberately NOT the executor
+    // config's `attested_block_height` (max(store, solo)+1): solo ingress
+    // advances `solo.height` per submission, so consulting it here made the
+    // FIRST promotion land at height 2+ and offset the whole ladder. The
+    // ingress-side `solo.height` bookkeeping is left untouched (other readers
+    // consult it); promotion simply no longer derives its height from it.
+    let new_height = s
+        .store
+        .latest_attested_root()
+        .ok()
+        .flatten()
+        .map(|r| r.height)
+        .unwrap_or(0)
+        .saturating_add(1);
+    let now = crate::executor_setup::wall_clock_secs();
+
+    let crate::state::IngressCommit {
+        receipt,
+        touched_post_cells,
+        prefix_root,
+        ..
+    } = ingress;
     let receipt_hash = receipt.receipt_hash();
     let receipt_hash_hex: String = receipt
         .turn_hash
@@ -5618,10 +5656,14 @@ async fn promote_ingress_committed_turn(
     let fed_receipt_opt =
         build_federation_receipt(&s, &signed_turn.turn, &receipt, new_height, block_id);
 
-    // ── AttestedRoot — identical to the executed path. The ledger already
-    // holds this turn's post-state (the ingress commit), so the canonical
-    // root binds the same committed state a re-executing validator computes.
-    let merkle_root = canonical_ledger_root(&s.ledger);
+    // ── AttestedRoot — from the PREFIX SNAPSHOT taken at ingress-commit time
+    // under the ingress write lock, NOT the live ledger. Two turns A,B
+    // ingress-committed inside the finality debounce mean the live ledger at
+    // A's promotion already includes B; re-reading it would anchor a root at
+    // A's height that no prefix through A reconstructs (prefix poisoning).
+    // The snapshot is exactly the canonical root a re-executing validator
+    // computes after applying the prefix through this turn.
+    let merkle_root = prefix_root;
     let note_tree_root: Option<[u8; 32]> = None;
     let timestamp_for_root = now;
     let federation_keys = s.known_federation_keys.clone();
@@ -5706,18 +5748,14 @@ async fn promote_ingress_committed_turn(
     }
 
     // ── Durable, crash-consistent commit record — same atomic boundary as the
-    // executed path, with the touched-cell overlay read from the ALREADY
-    // COMMITTED ledger for exactly the ids the ingress executor reported.
+    // executed path, with the touched-cell overlay from the INGRESS-TIME
+    // SNAPSHOT (the touched cells' post-states cloned under the ingress write
+    // lock, destroyed cells absent) — NOT re-read from the live ledger, which
+    // may already hold later turns' mutations (prefix poisoning). The
+    // retention entry is consumed ONLY on a successful durable write: a
+    // failure keeps it so a re-delivered/retried finalized block retries the
+    // promotion (guarded idempotent by the turn-by-hash check at the top).
     {
-        let mut touched_cells: Vec<dregg_cell::Cell> =
-            Vec::with_capacity(ingress.touched_cells.len());
-        for id in &ingress.touched_cells {
-            if let Some(cell) = s.ledger.get(id) {
-                touched_cells.push(cell.clone());
-            }
-            // A touched id absent post-commit was destroyed this turn; the
-            // overlay carries no stale entry (mirrors the executed path).
-        }
         let commit_record = dregg_persist::CommitRecord {
             ordinal: 0, // assigned by the store at the durable cursor
             height: new_height,
@@ -5727,7 +5765,7 @@ async fn promote_ingress_committed_turn(
             receipt_hash,
             ledger_root: merkle_root,
             block_executed_up_to,
-            touched_cells,
+            touched_cells: touched_post_cells,
         };
         let expected_ordinal = s.store.commit_cursor().unwrap_or(0);
         match s
@@ -5735,6 +5773,9 @@ async fn promote_ingress_committed_turn(
             .commit_finalized_turn(expected_ordinal, &commit_record)
         {
             Ok(assigned) => {
+                // Consume-on-success: the promotion is durable, the retained
+                // ingress result has served its purpose.
+                let _ = s.ingress_commits.remove(&computed_hash);
                 debug!(
                     turn_hash = %turn_hash_hex,
                     ordinal = assigned,
@@ -5752,7 +5793,9 @@ async fn promote_ingress_committed_turn(
                     turn_hash = %turn_hash_hex,
                     error = %e,
                     "DURABLE commit-log write FAILED for promoted ingress commit; \
-                     recovery will re-apply from the durable cursor"
+                     retention entry KEPT — a re-delivered finalized block retries \
+                     the promotion, and restart recovery re-applies from the \
+                     durable cursor"
                 );
             }
         }
@@ -7073,13 +7116,12 @@ mod tests {
             else {
                 panic!("ingress execution must commit");
             };
-            s.retain_ingress_commit(
-                computed_hash,
-                crate::state::IngressCommit {
-                    receipt,
-                    touched_cells: touched_cell_ids(&ledger_delta),
-                },
+            let ingress = crate::state::IngressCommit::snapshot(
+                &s.ledger,
+                receipt,
+                touched_cell_ids(&ledger_delta),
             );
+            s.retain_ingress_commit(computed_hash, ingress);
             let cell = s.ledger.get(&sender).expect("sender present");
             (cell.state.balance(), cell.state.nonce())
         };
@@ -7164,6 +7206,329 @@ mod tests {
             sender_balance_after_ingress,
             "conflicting turn moved no value (not laundered into success)"
         );
+    }
+
+    /// F1 (prefix poisoning) + F3 (height ladder) must-fail-pre.
+    ///
+    /// TWO disjoint-cell turns A,B ingress-commit inside the finality debounce
+    /// (both retained before ANY promotion), with real solo posture
+    /// (`solo.height` advanced per ingress, as the handlers do). Then A and B
+    /// promote in order. Pre-fix, promotion (a) read the LIVE ledger for the
+    /// AttestedRoot/CommitRecord — so A's height-1 root anchored the post-A+B
+    /// ledger, a root no prefix through A reconstructs — and (b) derived its
+    /// height via `max(store, solo)+1` — so the first promotion landed at
+    /// height 3 (solo.height was already 2). Post-fix: root(h1) == the
+    /// retained post-A prefix snapshot, root(h2) == post-A+B, heights are
+    /// exactly 1 then 2, and each CommitRecord's overlay carries its OWN
+    /// prefix's post-cells.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn promotion_anchors_ingress_prefix_snapshot_and_durable_heights() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = crate::state::NodeState::new(tmp.path(), Vec::new()).expect("node state");
+
+        {
+            let mut s = state.write().await;
+            s.lean_producer_enabled = false;
+            let signing_key = s.cclerk.gossip_signing_key().to_bytes();
+            s.solo_consensus = Some(dregg_federation::solo::SoloConsensusState::new(signing_key));
+        }
+        let federation_id = {
+            let s = state.read().await;
+            *blake3::hash(s.cclerk.public_key().as_bytes()).as_bytes()
+        };
+
+        // Two senders, two destinations — fully disjoint cell sets.
+        let a_cclerk = dregg_sdk::AgentCipherclerk::from_key_bytes(zeroize::Zeroizing::new(
+            *blake3::hash(b"prefix:sender-a").as_bytes(),
+        ));
+        let b_cclerk = dregg_sdk::AgentCipherclerk::from_key_bytes(zeroize::Zeroizing::new(
+            *blake3::hash(b"prefix:sender-b").as_bytes(),
+        ));
+        let a_pk = a_cclerk.public_key().0;
+        let b_pk = b_cclerk.public_key().0;
+        let sender_a = dregg_cell::CellId::derive_raw(&a_pk, &[0u8; 32]);
+        let sender_b = dregg_cell::CellId::derive_raw(&b_pk, &[0u8; 32]);
+        let dest_a = dregg_cell::CellId([0x4Au8; 32]);
+        let dest_b = dregg_cell::CellId([0x4Bu8; 32]);
+        {
+            let mut s = state.write().await;
+            s.ledger
+                .insert_cell(dregg_cell::Cell::with_balance(a_pk, [0u8; 32], 1_000_000))
+                .expect("fund sender A");
+            s.ledger
+                .insert_cell(dregg_cell::Cell::with_balance(b_pk, [0u8; 32], 1_000_000))
+                .expect("fund sender B");
+        }
+
+        let signed_a = signed_transfer_turn(&a_cclerk, sender_a, dest_a, 1_111, 0, &federation_id);
+        let signed_b = signed_transfer_turn(&b_cclerk, sender_b, dest_b, 2_222, 0, &federation_id);
+        let hash_a = signed_a.turn.hash();
+        let hash_b = signed_b.turn.hash();
+
+        // ── Both ingress commits + retentions BEFORE any promotion, exactly
+        // as the solo handlers do (execute in place, snapshot-retain under the
+        // same lock hold, advance solo.height).
+        let mut prefix_roots = Vec::new();
+        for signed in [&signed_a, &signed_b] {
+            let mut s = state.write().await;
+            let executor = crate::executor_setup::new_submit_executor(&s);
+            provision_transfer_destinations(&mut s.ledger, &signed.turn.call_forest);
+            let lean = s.lean_producer_enabled;
+            let exec_result = crate::executor_setup::execute_via_producer(
+                &executor,
+                &signed.turn,
+                &mut s.ledger,
+                lean,
+            );
+            let dregg_turn::TurnResult::Committed {
+                receipt,
+                ledger_delta,
+                ..
+            } = exec_result
+            else {
+                panic!("ingress execution must commit");
+            };
+            let ingress = crate::state::IngressCommit::snapshot(
+                &s.ledger,
+                receipt,
+                touched_cell_ids(&ledger_delta),
+            );
+            prefix_roots.push(ingress.prefix_root);
+            s.retain_ingress_commit(signed.turn.hash(), ingress);
+            if let Some(solo) = s.solo_consensus.as_mut() {
+                solo.advance_height();
+            }
+        }
+        assert_ne!(
+            prefix_roots[0], prefix_roots[1],
+            "B's ingress commit must move the canonical root (the poisoning distinguisher)"
+        );
+
+        let self_key = [0x77u8; 32];
+        let handle = test_handle_with_committee(self_key, vec![self_key]).await;
+
+        // ── Promote A. Height must be EXACTLY 1 (durable truth, not
+        // solo.height=2), and the root must be the retained post-A prefix.
+        let data_a = postcard::to_stdvec(&signed_a).expect("encode A");
+        execute_finalized_turn(&state, &handle, BlockId([0x31u8; 32]), &data_a, None, 0).await;
+        {
+            let s = state.read().await;
+            let latest = s
+                .store
+                .latest_attested_root()
+                .ok()
+                .flatten()
+                .expect("first promotion writes an attested root");
+            assert_eq!(
+                latest.height, 1,
+                "first promoted turn lands at exactly height 1 (durable truth, \
+                 independent of solo.height)"
+            );
+            assert_eq!(
+                latest.merkle_root, prefix_roots[0],
+                "height-1 root anchors the PREFIX through A (the ingress \
+                 snapshot), NOT the live post-A+B ledger"
+            );
+            let rec_a = s
+                .store
+                .lookup_turn(&hash_a)
+                .ok()
+                .flatten()
+                .expect("A's durable commit record");
+            assert_eq!(rec_a.height, 1);
+            assert_eq!(
+                rec_a.ledger_root, prefix_roots[0],
+                "A's CommitRecord binds A's own prefix root"
+            );
+            assert!(
+                rec_a
+                    .touched_cells
+                    .iter()
+                    .any(|c| c.id() == sender_a && c.state.nonce() == 1),
+                "A's overlay carries sender A's post-A state"
+            );
+            assert!(
+                rec_a
+                    .touched_cells
+                    .iter()
+                    .all(|c| c.id() != sender_b && c.id() != dest_b),
+                "A's overlay must NOT leak B's cells (its prefix excludes B)"
+            );
+        }
+
+        // ── Promote B. Height exactly 2; root is the post-A+B prefix, which
+        // is now also the live canonical root.
+        let data_b = postcard::to_stdvec(&signed_b).expect("encode B");
+        execute_finalized_turn(&state, &handle, BlockId([0x32u8; 32]), &data_b, None, 0).await;
+        {
+            let s = state.read().await;
+            let latest = s
+                .store
+                .latest_attested_root()
+                .ok()
+                .flatten()
+                .expect("second promotion writes an attested root");
+            assert_eq!(
+                latest.height, 2,
+                "second promoted turn lands at exactly height 2"
+            );
+            assert_eq!(
+                latest.merkle_root, prefix_roots[1],
+                "height-2 root anchors the prefix through B (post-A+B)"
+            );
+            assert_eq!(
+                prefix_roots[1],
+                canonical_ledger_root(&s.ledger),
+                "B's prefix root reconstructs the full committed ledger"
+            );
+            let rec_b = s
+                .store
+                .lookup_turn(&hash_b)
+                .ok()
+                .flatten()
+                .expect("B's durable commit record");
+            assert_eq!(rec_b.height, 2);
+            assert_eq!(rec_b.ledger_root, prefix_roots[1]);
+            assert!(
+                rec_b
+                    .touched_cells
+                    .iter()
+                    .any(|c| c.id() == sender_b && c.state.nonce() == 1),
+                "B's overlay carries sender B's post-B state"
+            );
+            assert!(
+                s.ingress_commits.is_empty(),
+                "both retention entries consumed on durable success"
+            );
+        }
+    }
+
+    /// F2 (consume-on-success) idempotence: a promotion whose retention entry
+    /// SURVIVES an already-durable write (a crash between the commit-log write
+    /// and the consume, or a retried delivery) must be a no-op — the durable
+    /// turn-by-hash guard detects the existing record, writes nothing, and
+    /// consumes the entry. Pre-fix the entry was `remove`d before the fallible
+    /// durable write, so this recovery shape could not exist at all (a failed
+    /// write orphaned the applied turn permanently).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn promotion_retry_with_surviving_entry_is_idempotent() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = crate::state::NodeState::new(tmp.path(), Vec::new()).expect("node state");
+
+        {
+            let mut s = state.write().await;
+            s.lean_producer_enabled = false;
+        }
+        let federation_id = {
+            let s = state.read().await;
+            *blake3::hash(s.cclerk.public_key().as_bytes()).as_bytes()
+        };
+        let sender_cclerk = dregg_sdk::AgentCipherclerk::from_key_bytes(zeroize::Zeroizing::new(
+            *blake3::hash(b"retry:sender").as_bytes(),
+        ));
+        let sender_pk = sender_cclerk.public_key().0;
+        let sender = dregg_cell::CellId::derive_raw(&sender_pk, &[0u8; 32]);
+        let dest = dregg_cell::CellId([0x6Eu8; 32]);
+        {
+            let mut s = state.write().await;
+            s.ledger
+                .insert_cell(dregg_cell::Cell::with_balance(
+                    sender_pk, [0u8; 32], 1_000_000,
+                ))
+                .expect("fund sender");
+        }
+        let signed = signed_transfer_turn(&sender_cclerk, sender, dest, 3_333, 0, &federation_id);
+        let computed_hash = signed.turn.hash();
+        let turn_data = postcard::to_stdvec(&signed).expect("encode");
+
+        let ingress_copy = {
+            let mut s = state.write().await;
+            let executor = crate::executor_setup::new_submit_executor(&s);
+            provision_transfer_destinations(&mut s.ledger, &signed.turn.call_forest);
+            let lean = s.lean_producer_enabled;
+            let exec_result = crate::executor_setup::execute_via_producer(
+                &executor,
+                &signed.turn,
+                &mut s.ledger,
+                lean,
+            );
+            let dregg_turn::TurnResult::Committed {
+                receipt,
+                ledger_delta,
+                ..
+            } = exec_result
+            else {
+                panic!("ingress execution must commit");
+            };
+            let ingress = crate::state::IngressCommit::snapshot(
+                &s.ledger,
+                receipt,
+                touched_cell_ids(&ledger_delta),
+            );
+            let copy = ingress.clone();
+            s.retain_ingress_commit(computed_hash, ingress);
+            copy
+        };
+
+        let self_key = [0x78u8; 32];
+        let handle = test_handle_with_committee(self_key, vec![self_key]).await;
+        let block_id = BlockId([0x41u8; 32]);
+        execute_finalized_turn(&state, &handle, block_id, &turn_data, None, 0).await;
+        {
+            let s = state.read().await;
+            assert_eq!(s.store.commit_cursor().unwrap_or(0), 1, "promotion landed");
+            assert!(
+                s.ingress_commits.is_empty(),
+                "entry consumed on durable success"
+            );
+        }
+
+        // The recovery shape: the entry survives although the durable record
+        // exists. Re-deliver the SAME finalized block.
+        {
+            let mut s = state.write().await;
+            s.retain_ingress_commit(computed_hash, ingress_copy);
+        }
+        execute_finalized_turn(&state, &handle, block_id, &turn_data, None, 0).await;
+        {
+            let s = state.read().await;
+            assert_eq!(
+                s.store.commit_cursor().unwrap_or(0),
+                1,
+                "retry is a NO-OP: no second commit record"
+            );
+            assert_eq!(
+                s.store
+                    .latest_attested_root()
+                    .ok()
+                    .flatten()
+                    .map(|r| r.height)
+                    .unwrap_or(0),
+                1,
+                "retry writes no second attested root"
+            );
+            assert!(
+                s.ingress_commits.is_empty(),
+                "the guard consumes the surviving entry"
+            );
+            let cell = s.ledger.get(&sender).expect("sender present");
+            assert_eq!(cell.state.nonce(), 1, "no re-execution on retry");
+        }
+    }
+
+    /// F4 backpressure: the ingress-side capacity check the three solo arms
+    /// consult BEFORE the in-place apply (a full retention map refuses the
+    /// submission — never evicts, since an evicted entry's mutation is already
+    /// committed in the live ledger).
+    #[test]
+    fn ingress_backpressure_threshold() {
+        use crate::state::{MAX_RETAINED_INGRESS_COMMITS, ingress_backlog_full};
+        assert!(!ingress_backlog_full(0));
+        assert!(!ingress_backlog_full(MAX_RETAINED_INGRESS_COMMITS - 1));
+        assert!(ingress_backlog_full(MAX_RETAINED_INGRESS_COMMITS));
+        assert!(ingress_backlog_full(MAX_RETAINED_INGRESS_COMMITS + 1));
     }
 
     /// A1 install mechanism + concurrency guard, in isolation and deterministic.
@@ -8511,6 +8876,37 @@ async fn apply_passed_proposal(
         let new_version = constitution.version();
         let new_threshold = constitution.threshold();
         drop(constitution);
+        // LIVE SOLO→MULTI CONTAINMENT: when a ratified membership change grows
+        // the participant set past one, atomically (under the state write
+        // lock, which every ingress handler holds across its is_solo read +
+        // in-place commit + retention — so an amendment can never interleave
+        // mid-handler) (a) clear the solo flag, so no further local turn is
+        // optimistically applied+cached against a stale mode, and (b) DRAIN
+        // the ingress promotion cache. A drained entry's turn re-executes at
+        // finalization and is nonce-replay-rejected (its mutation is already
+        // in the live ledger) — that is the pre-existing, recovery-covered
+        // regime, and STRICTLY better than promoting a stale solo execution
+        // result cross-validator without revalidation against the true tau
+        // pre-state. Runs BEFORE `apply_committee_change` so the ingress gate
+        // closes before the new committee is live.
+        if new_count > 1 {
+            let mut s = state.write().await;
+            if s.solo_consensus.as_ref().is_some_and(|sc| sc.is_solo) {
+                if let Some(solo) = s.solo_consensus.as_mut() {
+                    solo.detect_peers(); // clears is_solo, logs the transition
+                }
+                let drained = s.ingress_commits.len();
+                s.ingress_commits.clear();
+                warn!(
+                    drained,
+                    new_participant_count = new_count,
+                    "live solo→multi transition: solo ingress closed and \
+                     {drained} retained ingress commit(s) drained — their turns \
+                     re-execute at finalization (nonce-replay-rejected; \
+                     restart recovery re-applies from the durable cursor)"
+                );
+            }
+        }
         // HYBRID-PQ committee for the NEW participant set: genesis-published
         // keys from state, plus any continuing member's key the collector
         // already holds (e.g. our OWN locally-derived key on a bootstrap node

--- a/node/src/blocklace_sync.rs
+++ b/node/src/blocklace_sync.rs
@@ -4344,20 +4344,33 @@ async fn execute_finalized_turn(
     // turn hit this and finalization never accepted one (observed devnet:
     // executed=0, rejected=N; the turns stayed tentative).
     //
-    // Fix: if this exact turn (by hash) is already in the node's receipt chain AND
-    // we are solo, ingress already committed it authoritatively — treat finalization
-    // as idempotent-already-applied and skip re-execution. Scoped to solo so the
-    // multi-party paths are untouched: a foreign client's turn is NOT in the local
-    // chain here (ingress rolled back and did not append), and the operator's own
-    // multi-party turn rolled its ledger back (nonce NOT advanced), so both still
-    // execute normally below.
+    // Fix: if we are solo and this turn was already applied by ingress, treat
+    // finalization as idempotent-already-applied and skip re-execution. The precise
+    // "already applied" signal is the acting cell's nonce already being PAST the
+    // turn's nonce — exactly the condition that makes the executor's admission
+    // prologue reject the re-exec as `nonce replay: expected N, got N-1`. That single
+    // check covers BOTH ingress paths uniformly: the signed-turn `/turns/submit` path
+    // AND `/api/faucet` (whose turn commits via `post_faucet`, so its receipt is not
+    // in `s.cclerk` — a receipt-chain-only check misses it). The exact-hash
+    // receipt-chain match is kept as a belt-and-suspenders fallback for a self-
+    // creating first turn where the cell/nonce read is ambiguous.
+    //
+    // Scoped to solo so the multi-party paths are untouched: there, ingress rolled the
+    // ledger back (nonce NOT advanced) and a foreign client's turn is not in the local
+    // chain, so neither branch fires and the turn executes normally below. In solo,
+    // every finalized turn came from THIS node's own ingress, so a consumed nonce is
+    // always a legitimate already-applied turn, never a foreign replay.
     let is_solo = s.solo_consensus.as_ref().is_some_and(|sc| sc.is_solo);
-    if is_solo
-        && s.cclerk
-            .receipt_chain()
-            .iter()
-            .any(|r| r.turn_hash == computed_hash)
-    {
+    let already_applied = is_solo
+        && (s
+            .ledger
+            .get(&signed_turn.turn.agent)
+            .is_some_and(|c| c.state.nonce() > signed_turn.turn.nonce)
+            || s.cclerk
+                .receipt_chain()
+                .iter()
+                .any(|r| r.turn_hash == computed_hash));
+    if already_applied {
         debug!(
             turn_hash = %turn_hash_hex,
             block_id = %block_id,

--- a/node/src/blocklace_sync.rs
+++ b/node/src/blocklace_sync.rs
@@ -4330,53 +4330,46 @@ async fn execute_finalized_turn(
     // Execute the turn against the local ledger.
     let mut s = state.write().await;
 
-    // IDEMPOTENT FINALIZATION — solo double-apply fix.
+    // IDEMPOTENT FINALIZATION PROMOTION — solo double-apply fix (reworked per
+    // cross-family review of PR #54).
     //
-    // In SOLO mode the `/turns/submit` ingress path already applied this turn
-    // AUTHORITATIVELY: it kept the in-place ledger commit (`if !is_solo { rollback }`
-    // in api.rs is false for solo) AND appended the turn's receipt to the node
-    // chain (`if is_operator_agent || is_solo { append_receipt }`). Re-executing the
-    // same turn HERE double-applies it: the acting cell's nonce is already advanced
-    // past the turn's nonce, so the executor's admission prologue rejects it as
-    // `nonce replay: expected N, got N-1`. The stale premise this path was written
-    // against — "SOLO (n=1) has no finalization pass" (api.rs) — is no longer true:
-    // solo runs the blocklace and trivially finalizes every block, so EVERY solo
-    // turn hit this and finalization never accepted one (observed devnet:
-    // executed=0, rejected=N; the turns stayed tentative).
+    // In SOLO mode the ingress paths (`/turns/submit`, `/api/faucet`) already
+    // applied this turn AUTHORITATIVELY in place, so re-executing it here is
+    // rejected by the admission prologue as `nonce replay: expected N, got N-1`
+    // (observed devnet: executed=0, rejected=N; every turn stayed tentative and
+    // `latest_height` never advanced). But SKIPPING finalization entirely — the
+    // first version of this fix — is just as wrong: the turn then never gets its
+    // attested root, durable commit record, or note/nullifier persistence, so
+    // "0 rejections" proved only error suppression, never promotion.
     //
-    // Fix: if we are solo and this turn was already applied by ingress, treat
-    // finalization as idempotent-already-applied and skip re-execution. The precise
-    // "already applied" signal is the acting cell's nonce already being PAST the
-    // turn's nonce — exactly the condition that makes the executor's admission
-    // prologue reject the re-exec as `nonce replay: expected N, got N-1`. That single
-    // check covers BOTH ingress paths uniformly: the signed-turn `/turns/submit` path
-    // AND `/api/faucet` (whose turn commits via `post_faucet`, so its receipt is not
-    // in `s.cclerk` — a receipt-chain-only check misses it). The exact-hash
-    // receipt-chain match is kept as a belt-and-suspenders fallback for a self-
-    // creating first turn where the cell/nonce read is ambiguous.
-    //
-    // Scoped to solo so the multi-party paths are untouched: there, ingress rolled the
-    // ledger back (nonce NOT advanced) and a foreign client's turn is not in the local
-    // chain, so neither branch fires and the turn executes normally below. In solo,
-    // every finalized turn came from THIS node's own ingress, so a consumed nonce is
-    // always a legitimate already-applied turn, never a foreign replay.
-    let is_solo = s.solo_consensus.as_ref().is_some_and(|sc| sc.is_solo);
-    let already_applied = is_solo
-        && (s
-            .ledger
-            .get(&signed_turn.turn.agent)
-            .is_some_and(|c| c.state.nonce() > signed_turn.turn.nonce)
-            || s.cclerk
-                .receipt_chain()
-                .iter()
-                .any(|r| r.turn_hash == computed_hash));
-    if already_applied {
-        debug!(
-            turn_hash = %turn_hash_hex,
-            block_id = %block_id,
-            "finalized turn already applied by solo ingress (authoritative in-place commit); \
-             skipping re-execution to avoid double-apply nonce replay (idempotent finalization)"
-        );
+    // The rework: the ingress paths RETAIN their execution result (receipt +
+    // touched-cell set) in `ingress_commits`, keyed by EXACT turn hash, and this
+    // path CONSUMES the entry and runs the finalization phase without
+    // re-executing. Consuming the entry is the identity proof:
+    //  * exact-hash + retained result, not nonce heuristics — a conflicting
+    //    foreign turn at the same nonce hashes differently, MISSES the cache,
+    //    executes below, and is correctly rejected as a replay;
+    //  * no federation-mode check HERE — insertion is what is solo-gated, so the
+    //    cache only ever holds turns THIS node ingress-committed; a stale solo
+    //    flag after a live membership change can neither admit a foreign block's
+    //    turn nor skip a local one;
+    //  * consume-once (`remove`) — a re-delivered block re-executes and the
+    //    executor's own replay rejection stands.
+    if let Some(ingress) = s.ingress_commits.remove(&computed_hash) {
+        drop(s);
+        promote_ingress_committed_turn(
+            state,
+            handle,
+            block_id,
+            finality_round,
+            &signed_turn,
+            computed_hash,
+            &turn_hash_hex,
+            ingress,
+            artifacts,
+            block_executed_up_to,
+        )
+        .await;
         return;
     }
 
@@ -5510,6 +5503,292 @@ async fn execute_finalized_turn(
             );
         }
     }
+}
+
+/// Finalization PROMOTION of a turn this node already applied authoritatively
+/// at solo ingress (see `NodeStateInner::ingress_commits`): runs the
+/// finalization phase — attested root, durable commit record, note-commitment
+/// + spent-nullifier persistence, pending-turn resolution — reusing the
+/// RETAINED ingress receipt and touched-cell set instead of re-executing the
+/// turn (re-execution is a guaranteed `nonce replay` rejection; that was the
+/// double-apply bug).
+///
+/// Deliberately NOT repeated from the executed path, because ingress already
+/// did them for this turn: the receipt-chain append (retried below only if the
+/// receipt is absent — e.g. a faucet receipt the chain refused), the
+/// activity-feed push, async proving, and the `Receipt` WS event. The chain
+/// entry remains the ingress-signed TENTATIVE receipt (the chain is
+/// append-only and finality is bound into the receipt hash); consensus
+/// finality for a promoted turn is expressed by the attested root + durable
+/// commit record written here, which is what recovery and finality readers
+/// consult.
+#[allow(clippy::too_many_arguments)]
+async fn promote_ingress_committed_turn(
+    state: &NodeState,
+    handle: &BlocklaceHandle,
+    block_id: BlockId,
+    finality_round: Option<u64>,
+    signed_turn: &dregg_sdk::SignedTurn,
+    computed_hash: [u8; 32],
+    turn_hash_hex: &str,
+    ingress: crate::state::IngressCommit,
+    artifacts: Option<&TurnArtifactBundle>,
+    block_executed_up_to: u64,
+) {
+    let mut s = state.write().await;
+
+    // Height/timestamp exactly as the executed path derives them: a configured
+    // executor's `block_height` (Next) and clock. Nothing is executed with it.
+    let mut height_exec = dregg_turn::TurnExecutor::new(dregg_turn::ComputronCosts::default());
+    crate::executor_setup::configure_turn_executor(
+        &mut height_exec,
+        &s,
+        crate::executor_setup::BlockHeightMode::Next,
+    );
+    let new_height = height_exec.block_height;
+    let now = height_exec.current_timestamp;
+
+    let receipt = ingress.receipt;
+    let receipt_hash = receipt.receipt_hash();
+    let receipt_hash_hex: String = receipt
+        .turn_hash
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
+
+    let invalid_bundle_evidence = if let Some(bundle) = artifacts {
+        materialize_blocklace_artifacts(&mut s, block_id, &receipt, bundle)
+    } else {
+        Vec::new()
+    };
+
+    // Resolve any pending turns waiting on this receipt (idempotent when the
+    // ingress path already resolved them).
+    s.pending_turns.resolve(
+        computed_hash,
+        dregg_turn::ResolutionOutcome::Resolved(receipt.clone()),
+    );
+
+    // Note commitments + spent-nullifier persistence are FINALIZATION-phase
+    // work — the ingress commit did not persist them (only this path does).
+    for tree in &signed_turn.turn.call_forest.roots {
+        for effect in &tree.action.effects {
+            if let dregg_turn::Effect::NoteCreate { commitment, .. } = effect {
+                s.note_tree_append_commitment(&commitment.0);
+                let _ = s.store.store_note_commitment(commitment);
+            }
+        }
+    }
+    {
+        let spent: Vec<dregg_turn::Effect> = signed_turn
+            .turn
+            .call_forest
+            .total_effects()
+            .into_iter()
+            .cloned()
+            .collect();
+        for nf in crate::turn_proving::spent_nullifiers(&spent) {
+            if let Err(e) = s.store.store_nullifier(&dregg_cell::note::Nullifier(nf)) {
+                warn!(error = %e, "failed to persist spent note nullifier");
+            }
+        }
+    }
+
+    // Ingress normally appended this receipt to the node chain already; retry
+    // only if it is absent (e.g. `post_faucet`'s append can be refused by the
+    // chain), so a promoted turn is not silently missing from the chain when
+    // an append IS possible. A failure here is surfaced but does not block the
+    // promotion — the attested root + durable record below are the
+    // consensus-finality artifacts.
+    if !s
+        .cclerk
+        .receipt_chain()
+        .iter()
+        .any(|r| r.turn_hash == computed_hash)
+        && let Err(e) = s.cclerk.append_receipt(receipt.clone())
+    {
+        warn!(
+            turn_hash = %turn_hash_hex,
+            error = %e,
+            "ingress-committed receipt not appendable at finalization promotion; \
+             continuing (attested root + durable commit record still written)"
+        );
+    }
+
+    let fed_receipt_opt =
+        build_federation_receipt(&s, &signed_turn.turn, &receipt, new_height, block_id);
+
+    // ── AttestedRoot — identical to the executed path. The ledger already
+    // holds this turn's post-state (the ingress commit), so the canonical
+    // root binds the same committed state a re-executing validator computes.
+    let merkle_root = canonical_ledger_root(&s.ledger);
+    let note_tree_root: Option<[u8; 32]> = None;
+    let timestamp_for_root = now;
+    let federation_keys = s.known_federation_keys.clone();
+    let federation_threshold = s.decryption_threshold.max(1);
+    let signing_key_bytes = s.cclerk.gossip_signing_key().to_bytes();
+
+    let receipt_stream_root = Some(dregg_types::merkle_root_of_receipt_hashes(&[receipt_hash]));
+
+    let mut attested = dregg_types::AttestedRoot {
+        merkle_root,
+        note_tree_root,
+        nullifier_set_root: None,
+        height: new_height,
+        timestamp: timestamp_for_root,
+        blocklace_block_id: Some(block_id.0),
+        finality_round,
+        quorum_signatures: Vec::new(),
+        threshold_qc: None,
+        threshold: federation_threshold,
+        federation_id: dregg_types::FederationId(s.federation_id),
+        receipt_stream_root,
+        hybrid_quorum: Vec::new(),
+    };
+    let signing_msg = attested.signing_message();
+    let local_pk = s.cclerk.public_key();
+    let signing_key = dregg_types::SigningKey::from_bytes(&signing_key_bytes);
+    let sig = dregg_types::sign(&signing_key, &signing_msg);
+    if federation_keys.is_empty() || federation_keys.contains(&local_pk) {
+        attested.quorum_signatures.push((local_pk, sig));
+    }
+
+    let finalization_quorum = handle
+        .votes
+        .read()
+        .await
+        .assembled_quorum(&block_id)
+        .filter(|(root, _)| *root == attested.merkle_root)
+        .map(|(_, sigs)| sigs)
+        .unwrap_or_default();
+
+    attested.hybrid_quorum = finalization_quorum
+        .iter()
+        .map(|qs| dregg_types::HybridQuorumSig {
+            pubkey: qs.voter,
+            signature: qs.signature,
+            ml_dsa_pubkey: qs.ml_dsa_pubkey.clone(),
+            pq_signature: qs.pq_signature.clone(),
+        })
+        .collect();
+
+    let stored = dregg_persist::StoredAttestedRoot {
+        merkle_root: attested.merkle_root,
+        note_tree_root: attested.note_tree_root,
+        nullifier_set_root: attested.nullifier_set_root,
+        height: attested.height,
+        timestamp: attested.timestamp,
+        blocklace_block_id: attested.blocklace_block_id,
+        finality_round: attested.finality_round,
+        quorum_signatures: attested.quorum_signatures.clone(),
+        threshold_qc: attested.threshold_qc.clone(),
+        threshold: attested.threshold,
+        federation_id: attested.federation_id,
+        receipt_stream_root: attested.receipt_stream_root,
+        finalization_quorum,
+    };
+    if let Err(e) = s.store.store_attested_root(&stored) {
+        warn!(error = %e, height = new_height, "failed to persist attested root");
+    }
+
+    state.emit(NodeEvent::Root {
+        height: new_height,
+        merkle_root: dregg_types::hex_encode(&stored.merkle_root),
+        timestamp: stored.timestamp,
+    });
+
+    for effect in signed_turn.turn.call_forest.total_effects() {
+        if let dregg_turn::Effect::RevokeCapability { cell, .. } = effect {
+            state.emit(NodeEvent::Revocation {
+                token_id: dregg_types::hex_encode(&cell.0),
+            });
+        }
+    }
+
+    // ── Durable, crash-consistent commit record — same atomic boundary as the
+    // executed path, with the touched-cell overlay read from the ALREADY
+    // COMMITTED ledger for exactly the ids the ingress executor reported.
+    {
+        let mut touched_cells: Vec<dregg_cell::Cell> =
+            Vec::with_capacity(ingress.touched_cells.len());
+        for id in &ingress.touched_cells {
+            if let Some(cell) = s.ledger.get(id) {
+                touched_cells.push(cell.clone());
+            }
+            // A touched id absent post-commit was destroyed this turn; the
+            // overlay carries no stale entry (mirrors the executed path).
+        }
+        let commit_record = dregg_persist::CommitRecord {
+            ordinal: 0, // assigned by the store at the durable cursor
+            height: new_height,
+            block_id: block_id.0,
+            turn_hash: computed_hash,
+            creator: *signed_turn.turn.agent.as_bytes(),
+            receipt_hash,
+            ledger_root: merkle_root,
+            block_executed_up_to,
+            touched_cells,
+        };
+        let expected_ordinal = s.store.commit_cursor().unwrap_or(0);
+        match s
+            .store
+            .commit_finalized_turn(expected_ordinal, &commit_record)
+        {
+            Ok(assigned) => {
+                debug!(
+                    turn_hash = %turn_hash_hex,
+                    ordinal = assigned,
+                    block_executed_up_to,
+                    "durable commit-log record written for PROMOTED ingress commit (atomic)"
+                );
+                let mirrored = dregg_persist::CommitRecord {
+                    ordinal: assigned,
+                    ..commit_record.clone()
+                };
+                s.mirror_committed_record(&mirrored);
+            }
+            Err(e) => {
+                error!(
+                    turn_hash = %turn_hash_hex,
+                    error = %e,
+                    "DURABLE commit-log write FAILED for promoted ingress commit; \
+                     recovery will re-apply from the durable cursor"
+                );
+            }
+        }
+    }
+
+    drop(s);
+
+    for evidence in invalid_bundle_evidence {
+        warn!(
+            block_id = %evidence.block_id,
+            reason = %evidence.reason,
+            "invalid blocklace turn bundle artifacts"
+        );
+        state.emit(NodeEvent::InvalidBlocklaceBundle {
+            block_id: evidence.block_id.to_string(),
+            reason: evidence.reason,
+        });
+    }
+
+    if let Some(fed_receipt) = fed_receipt_opt {
+        tracing::debug!(
+            federation_id = %dregg_types::hex_encode(&fed_receipt.federation_id),
+            height = fed_receipt.body.block_height,
+            "federation receipt produced",
+        );
+    }
+
+    info!(
+        turn_hash = %turn_hash_hex,
+        receipt_hash = %receipt_hash_hex,
+        block_id = %block_id,
+        height = new_height,
+        round = ?finality_round,
+        "finalized turn PROMOTED from ingress commit (no re-execution; \
+         attested root + durable commit record written)"
+    );
 }
 
 fn materialize_blocklace_artifacts(
@@ -6719,6 +6998,171 @@ mod tests {
                 .balance(),
             1_000_000 - 4_200 - signed.turn.fee as i64,
             "sender debited by amount + burned fee"
+        );
+    }
+
+    /// PR #54 rework — finalization PROMOTION of a solo ingress commit, plus
+    /// the exact-hash negative (no laundering).
+    ///
+    /// Simulates the solo ingress leg exactly as `/turns/submit` performs it
+    /// (authoritative in-place execute through the producer gate + retention
+    /// via `retain_ingress_commit`), then drives the REAL
+    /// `execute_finalized_turn`. Must-fail-pre: the first PR #54 guard
+    /// early-returned on the retained turn and wrote NO finalization artifacts
+    /// (attested height stayed 0, commit cursor unchanged) — this test pins
+    /// the full promotion contract:
+    ///  1. no re-execution — the nonce/balances applied exactly once,
+    ///  2. attested height advances 0 -> 1,
+    ///  3. the durable commit cursor advances (crash-consistent record),
+    ///  4. consume-once — the retention entry is gone,
+    ///  5. NEGATIVE: a CONFLICTING turn at the same nonce (different hash)
+    ///     misses the cache, re-executes, and is REJECTED — never laundered
+    ///     into an idempotent success (no height advance, no value moved).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn solo_ingress_commit_promotes_without_reexecution_and_never_launders() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state = crate::state::NodeState::new(tmp.path(), Vec::new()).expect("node state");
+
+        {
+            let mut s = state.write().await;
+            s.lean_producer_enabled = false;
+        }
+        let federation_id = {
+            let s = state.read().await;
+            *blake3::hash(s.cclerk.public_key().as_bytes()).as_bytes()
+        };
+
+        let sender_cclerk = dregg_sdk::AgentCipherclerk::from_key_bytes(zeroize::Zeroizing::new(
+            *blake3::hash(b"promotion:sender").as_bytes(),
+        ));
+        let sender_pk = sender_cclerk.public_key().0;
+        let sender = dregg_cell::CellId::derive_raw(&sender_pk, &[0u8; 32]);
+        let dest = dregg_cell::CellId([0x5Du8; 32]);
+        {
+            let mut s = state.write().await;
+            s.ledger
+                .insert_cell(dregg_cell::Cell::with_balance(
+                    sender_pk, [0u8; 32], 1_000_000,
+                ))
+                .expect("fund sender");
+        }
+
+        let signed = signed_transfer_turn(&sender_cclerk, sender, dest, 4_200, 0, &federation_id);
+        let computed_hash = signed.turn.hash();
+        let turn_data = postcard::to_stdvec(&signed).expect("encode signed turn");
+
+        // ── The solo ingress leg: authoritative in-place commit + retention,
+        // exactly what `post_submit_signed_turn` does under `is_solo`.
+        let (sender_balance_after_ingress, sender_nonce_after_ingress) = {
+            let mut s = state.write().await;
+            let executor = crate::executor_setup::new_submit_executor(&s);
+            provision_transfer_destinations(&mut s.ledger, &signed.turn.call_forest);
+            let lean = s.lean_producer_enabled;
+            let exec_result = crate::executor_setup::execute_via_producer(
+                &executor,
+                &signed.turn,
+                &mut s.ledger,
+                lean,
+            );
+            let dregg_turn::TurnResult::Committed {
+                receipt,
+                ledger_delta,
+                ..
+            } = exec_result
+            else {
+                panic!("ingress execution must commit");
+            };
+            s.retain_ingress_commit(
+                computed_hash,
+                crate::state::IngressCommit {
+                    receipt,
+                    touched_cells: touched_cell_ids(&ledger_delta),
+                },
+            );
+            let cell = s.ledger.get(&sender).expect("sender present");
+            (cell.state.balance(), cell.state.nonce())
+        };
+        assert_eq!(
+            sender_nonce_after_ingress, 1,
+            "ingress applied the turn once"
+        );
+
+        let self_key = [0x9Bu8; 32];
+        let handle = test_handle_with_committee(self_key, vec![self_key]).await;
+
+        // ── Finalization: MUST promote (write artifacts), not re-execute.
+        execute_finalized_turn(&state, &handle, BlockId([0x21u8; 32]), &turn_data, None, 0).await;
+
+        {
+            let s = state.read().await;
+            let height = s
+                .store
+                .latest_attested_root()
+                .ok()
+                .flatten()
+                .map(|r| r.height)
+                .unwrap_or(0);
+            assert_eq!(
+                height, 1,
+                "promotion MUST write the attested root (height 0 -> 1); \
+                 skipping finalization artifacts was the reviewed blocker"
+            );
+            assert_eq!(
+                s.store.commit_cursor().unwrap_or(0),
+                1,
+                "promotion MUST write the durable commit record (cursor 0 -> 1)"
+            );
+            let cell = s.ledger.get(&sender).expect("sender present");
+            assert_eq!(
+                cell.state.nonce(),
+                1,
+                "nonce applied EXACTLY once (no re-execution at finalization)"
+            );
+            assert_eq!(
+                cell.state.balance(),
+                sender_balance_after_ingress,
+                "finalization moved no value (the ingress commit was authoritative)"
+            );
+            assert!(
+                s.ingress_commits.is_empty(),
+                "retention entry consumed exactly once"
+            );
+        }
+
+        // ── NEGATIVE: a conflicting turn at the SAME nonce but different
+        // content (different hash) must NOT be treated as already-applied.
+        let conflicting =
+            signed_transfer_turn(&sender_cclerk, sender, dest, 9_999, 0, &federation_id);
+        assert_ne!(conflicting.turn.hash(), computed_hash);
+        let conflicting_data = postcard::to_stdvec(&conflicting).expect("encode");
+        execute_finalized_turn(
+            &state,
+            &handle,
+            BlockId([0x22u8; 32]),
+            &conflicting_data,
+            None,
+            0,
+        )
+        .await;
+
+        let s = state.read().await;
+        assert_eq!(
+            s.store
+                .latest_attested_root()
+                .ok()
+                .flatten()
+                .map(|r| r.height)
+                .unwrap_or(0),
+            1,
+            "a conflicting same-nonce turn must be rejected, never promoted"
+        );
+        let cell = s.ledger.get(&sender).expect("sender present");
+        assert_eq!(cell.state.nonce(), 1, "conflicting turn applied nothing");
+        assert_eq!(
+            cell.state.balance(),
+            sender_balance_after_ingress,
+            "conflicting turn moved no value (not laundered into success)"
         );
     }
 
@@ -8250,7 +8694,7 @@ fn build_federation_receipt(
 /// snapshots into the cell-by-id index, so recovery reconstructs the finalized
 /// ledger from (checkpoint ⊕ overlay) without re-execution. Deduplicated and
 /// order-stable.
-fn touched_cell_ids(delta: &dregg_cell::LedgerDelta) -> Vec<dregg_cell::CellId> {
+pub(crate) fn touched_cell_ids(delta: &dregg_cell::LedgerDelta) -> Vec<dregg_cell::CellId> {
     let mut ids: Vec<dregg_cell::CellId> = Vec::new();
     fn push(ids: &mut Vec<dregg_cell::CellId>, id: dregg_cell::CellId) {
         if !ids.contains(&id) {

--- a/node/src/executor_setup.rs
+++ b/node/src/executor_setup.rs
@@ -42,7 +42,10 @@ pub fn federation_id_for_executor(s: &NodeStateInner) -> [u8; 32] {
     }
 }
 
-fn wall_clock_secs() -> i64 {
+/// Wall-clock seconds — the timestamp source `configure_turn_executor` seeds
+/// executors with; also used directly by the finalization-promotion path
+/// (which derives its height from the durable store, not an executor config).
+pub fn wall_clock_secs() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)

--- a/node/src/starbridge_seed.rs
+++ b/node/src/starbridge_seed.rs
@@ -377,23 +377,38 @@ fn seed_one_cell(
         owner_pubkey,
     };
 
-    let mut turn = app_cclerk
-        .shared_cipherclerk()
-        .read()
-        .unwrap()
-        .create_from_factory(
-            issuer_cell,
-            factory_vk,
-            owner_pubkey,
-            token_id,
-            params,
-            &federation_id,
-        );
-    turn.fee = 2_000;
-    turn.nonce = ledger
+    // NONCE BEFORE SIGNING — the `dregg-action-sig-v3` per-action signing
+    // message BINDS the submitting turn's nonce, and the executor recomputes
+    // it with `turn.nonce`. `create_from_factory` signs via `make_action`,
+    // which uses THIS fresh clerk's `next_turn_nonce()` (= 0, empty receipt
+    // chain) — but the turn carries the ISSUER CELL's ledger nonce, which
+    // advances with every committed seed turn. All ten default cells share
+    // one issuer ("alice"), so every seed turn after the first carried a
+    // nonce its action signature was not computed over. Compute the carried
+    // nonce first, then re-sign the built action over it (same fix class as
+    // the faucet's `sign_action_hybrid` path in `api.rs::post_faucet`).
+    let seed_nonce = ledger
         .get(&issuer_cell)
         .map(|c| c.state.nonce())
         .unwrap_or(0);
+    let shared = app_cclerk.shared_cipherclerk();
+    let clerk = shared.read().unwrap();
+    let mut turn = clerk.create_from_factory(
+        issuer_cell,
+        factory_vk,
+        owner_pubkey,
+        token_id,
+        params,
+        &federation_id,
+    );
+    turn.fee = 2_000;
+    turn.nonce = seed_nonce;
+    // Re-sign each root action over the nonce the turn actually carries
+    // (`sign_action_hybrid` strips the stale authorization before signing).
+    for root in &mut turn.call_forest.roots {
+        root.action = clerk.sign_action_hybrid(root.action.clone(), &federation_id, seed_nonce);
+    }
+    drop(clerk);
     // Link to the issuer's prior seed receipt (if any) so the executor's
     // per-agent receipt chain validates. The first turn from this issuer carries
     // `None` (genesis chain head); each subsequent one links to the last commit.
@@ -597,6 +612,25 @@ mod tests {
         let parsed = parse_starbridge_cells(&genesis).expect("parse cells");
         assert_eq!(parsed.len(), 10);
         assert_eq!(parsed[0].label, "nameservice-registry");
+    }
+
+    /// End-to-end devnet backfill over a fresh ledger: all ten default cells
+    /// share ONE issuer ("alice"), whose cell nonce advances with every
+    /// committed seed turn — so this exercises the dregg-action-sig-v3 nonce
+    /// binding across turns. Before the carried-nonce re-sign, only the first
+    /// cell seeded; turns 2..10 carried a nonce their action signature was
+    /// not computed over and failed signature verification.
+    #[test]
+    fn devnet_seed_creates_all_default_cells_across_advancing_issuer_nonce() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut ledger = dregg_cell::Ledger::new();
+        let stats = seed_default_starbridge_cells_devnet(dir.path(), &mut ledger, [7u8; 32], None);
+        assert_eq!(
+            stats.failed, 0,
+            "every seed turn must verify (action signature bound to the carried nonce): {stats:?}"
+        );
+        assert_eq!(stats.skipped, 0, "devnet fallback materializes everything");
+        assert_eq!(stats.created, 10, "all ten default starbridge cells seed");
     }
 
     #[test]

--- a/node/src/state.rs
+++ b/node/src/state.rs
@@ -147,19 +147,80 @@ pub struct NodeState {
 }
 
 /// The retained result of a solo-ingress authoritative in-place commit,
-/// consumed once by finalization promotion (see
+/// consumed by finalization promotion (see
 /// [`NodeStateInner::ingress_commits`]). Holds exactly what the finalization
 /// phase needs that only the ingress execution knew: the committed receipt
-/// (as appended/attempted on the chain — tentative-signed) and the complete
-/// touched-cell set from the executor's `LedgerDelta`.
+/// (as appended/attempted on the chain — tentative-signed), the complete
+/// touched-cell set from the executor's `LedgerDelta`, and — CRITICALLY — the
+/// PREFIX SNAPSHOT taken at ingress-commit time under the same exclusive
+/// write lock that applied the turn. Solo ingress is serialized under that
+/// lock, so ingress order IS the prefix order: the snapshot binds exactly the
+/// ledger prefix through THIS turn. Promotion writes the snapshot into the
+/// AttestedRoot / CommitRecord instead of re-reading the live ledger — two
+/// turns ingress-committed inside the finality debounce would otherwise
+/// anchor turn A's root/overlay over a ledger that already includes turn B
+/// (prefix poisoning: height-h artifacts no longer reconstruct the exact
+/// prefix through h).
+#[derive(Clone)]
 pub struct IngressCommit {
     /// The receipt the ingress executor committed (solo: finality downgraded
     /// to `Tentative` and node-re-signed before retention).
     pub receipt: dregg_turn::TurnReceipt,
     /// `touched_cell_ids(ledger_delta)` at ingress — the authoritative,
-    /// bounded set of cells this turn mutated, for the durable commit
-    /// record's cell overlay.
+    /// bounded set of cells this turn mutated. Kept alongside the post-state
+    /// clones below because a DESTROYED cell has an id here but no post-state
+    /// entry (the overlay carries no stale entry for it, mirroring the
+    /// executed path).
     pub touched_cells: Vec<CellId>,
+    /// The touched cells' POST-STATES cloned from the just-committed ledger at
+    /// ingress time — the durable commit record's cell overlay for the prefix
+    /// through this turn (NOT re-read from the live ledger at promotion).
+    pub touched_post_cells: Vec<Cell>,
+    /// `canonical_ledger_root` computed right after the in-place commit, under
+    /// the ingress write lock — the AttestedRoot merkle root for the prefix
+    /// through this turn. (Same O(ledger) hash the executed path pays per
+    /// finalized turn: cost parity.)
+    pub prefix_root: [u8; 32],
+}
+
+impl IngressCommit {
+    /// Build the retained ingress commit by SNAPSHOTTING the just-committed
+    /// ledger: clone the touched cells' post-states (destroyed cells are
+    /// simply absent) and bind the canonical prefix root. MUST be called
+    /// under the same exclusive write lock that applied the turn, immediately
+    /// after the in-place commit — that lock hold is what makes the snapshot
+    /// the exact prefix through this turn.
+    pub fn snapshot(
+        ledger: &Ledger,
+        receipt: dregg_turn::TurnReceipt,
+        touched_cells: Vec<CellId>,
+    ) -> Self {
+        let touched_post_cells = touched_cells
+            .iter()
+            .filter_map(|id| ledger.get(id).cloned())
+            .collect();
+        let prefix_root = dregg_persist::canonical_ledger_root(ledger);
+        Self {
+            receipt,
+            touched_cells,
+            touched_post_cells,
+            prefix_root,
+        }
+    }
+}
+
+/// Capacity of [`NodeStateInner::ingress_commits`]. When the retention map is
+/// full the ingress paths REFUSE new solo submissions BEFORE the in-place
+/// apply (backpressure) — never evict: an evicted entry's mutation is already
+/// in the live ledger, so its later promotion would nonce-replay-reject and
+/// every LATER promoted root would contain an undurable mutation recovery
+/// cannot reconstruct.
+pub const MAX_RETAINED_INGRESS_COMMITS: usize = 8192;
+
+/// Whether a retention map of `retained` entries is at capacity — the
+/// ingress-side backpressure check (see [`MAX_RETAINED_INGRESS_COMMITS`]).
+pub fn ingress_backlog_full(retained: usize) -> bool {
+    retained >= MAX_RETAINED_INGRESS_COMMITS
 }
 
 /// The inner mutable state of the node.
@@ -1710,24 +1771,23 @@ impl NodeState {
 // =============================================================================
 
 impl NodeStateInner {
+    /// Whether the solo-ingress retention map is at capacity. The ingress
+    /// paths call this BEFORE the in-place apply and refuse the submission
+    /// when full ("finalization backlog"), so no authoritative in-place
+    /// mutation can ever exist without a retained promotion entry.
+    pub fn ingress_commits_full(&self) -> bool {
+        ingress_backlog_full(self.ingress_commits.len())
+    }
+
     /// Retain a solo-ingress execution result for finalization promotion
-    /// (see [`NodeStateInner::ingress_commits`]). Bounded: if finalization
-    /// stalls pathologically, an arbitrary entry is evicted with a warning —
-    /// an evicted turn falls back to the re-execute path (rejected as a
-    /// replay, exactly the pre-cache regime) and the durable-cursor recovery
-    /// re-applies it after a restart, so eviction degrades liveness of the
-    /// promotion, never safety.
+    /// (see [`NodeStateInner::ingress_commits`]). NEVER evicts: an entry's
+    /// mutation is already committed in the live ledger, so dropping it would
+    /// turn its later promotion into a nonce-replay rejection and leave every
+    /// LATER promoted root carrying an undurable mutation recovery cannot
+    /// reconstruct. Capacity is enforced upstream as ingress backpressure
+    /// ([`Self::ingress_commits_full`] refuses the submission before the
+    /// in-place apply).
     pub fn retain_ingress_commit(&mut self, turn_hash: [u8; 32], commit: IngressCommit) {
-        const MAX_RETAINED: usize = 8192;
-        if self.ingress_commits.len() >= MAX_RETAINED {
-            tracing::warn!(
-                retained = self.ingress_commits.len(),
-                "ingress-commit retention full (finalization stalled?); evicting one entry"
-            );
-            if let Some(k) = self.ingress_commits.keys().next().copied() {
-                let _ = self.ingress_commits.remove(&k);
-            }
-        }
         let _ = self.ingress_commits.insert(turn_hash, commit);
     }
 

--- a/node/src/state.rs
+++ b/node/src/state.rs
@@ -146,6 +146,22 @@ pub struct NodeState {
     prove_pool: Arc<RwLock<Option<crate::prove_pool::ProvePool>>>,
 }
 
+/// The retained result of a solo-ingress authoritative in-place commit,
+/// consumed once by finalization promotion (see
+/// [`NodeStateInner::ingress_commits`]). Holds exactly what the finalization
+/// phase needs that only the ingress execution knew: the committed receipt
+/// (as appended/attempted on the chain — tentative-signed) and the complete
+/// touched-cell set from the executor's `LedgerDelta`.
+pub struct IngressCommit {
+    /// The receipt the ingress executor committed (solo: finality downgraded
+    /// to `Tentative` and node-re-signed before retention).
+    pub receipt: dregg_turn::TurnReceipt,
+    /// `touched_cell_ids(ledger_delta)` at ingress — the authoritative,
+    /// bounded set of cells this turn mutated, for the durable commit
+    /// record's cell overlay.
+    pub touched_cells: Vec<CellId>,
+}
+
 /// The inner mutable state of the node.
 // Some fields back cfg-conditional / not-yet-consulted node surfaces (routing,
 // cross-federation revocation, threshold shares); retained as wired scaffolding.
@@ -195,6 +211,18 @@ pub struct NodeStateInner {
     /// Set of proof hashes that have already been used (nullifiers).
     /// Prevents the same proof from satisfying multiple conditional turns.
     pub used_proof_hashes: HashSet<[u8; 32]>,
+    /// Solo-ingress authoritative commits awaiting blocklace finalization
+    /// PROMOTION, keyed by EXACT turn hash. `/turns/submit` and `/api/faucet`
+    /// retain their execution result here when they commit in place (solo);
+    /// `execute_finalized_turn` consumes an entry and runs the finalization
+    /// phase (attested root, durable commit record, note/nullifier
+    /// persistence) WITHOUT re-executing the turn — re-execution would be
+    /// rejected as a nonce replay (the double-apply bug). Exact-hash identity:
+    /// a conflicting foreign turn at the same nonce hashes differently, misses
+    /// this cache, and takes the normal execution path. RAM-only by design:
+    /// after a restart the durable-cursor recovery re-applies any turn that
+    /// never got its commit record.
+    pub ingress_commits: HashMap<[u8; 32], IngressCommit>,
     /// Known federation public keys for attested root quorum verification.
     ///
     /// Per FEDERATION-UNIFICATION-DESIGN.md §5/§8 this is now a *derived*
@@ -932,6 +960,7 @@ impl NodeState {
                 pending_conditionals: Vec::new(),
                 pending_turns: dregg_turn::PendingTurnRegistry::new(),
                 used_proof_hashes,
+                ingress_commits: HashMap::new(),
                 known_federation_keys: Vec::new(),
                 known_federation_ml_dsa_keys: Vec::new(),
                 known_federations: dregg_federation::KnownFederations::new(),
@@ -1122,6 +1151,7 @@ impl NodeState {
                 pending_conditionals: Vec::new(),
                 pending_turns: dregg_turn::PendingTurnRegistry::new(),
                 used_proof_hashes: HashSet::new(),
+                ingress_commits: HashMap::new(),
                 known_federation_keys: Vec::new(),
                 known_federation_ml_dsa_keys: Vec::new(),
                 known_federations: dregg_federation::KnownFederations::new(),
@@ -1680,6 +1710,27 @@ impl NodeState {
 // =============================================================================
 
 impl NodeStateInner {
+    /// Retain a solo-ingress execution result for finalization promotion
+    /// (see [`NodeStateInner::ingress_commits`]). Bounded: if finalization
+    /// stalls pathologically, an arbitrary entry is evicted with a warning —
+    /// an evicted turn falls back to the re-execute path (rejected as a
+    /// replay, exactly the pre-cache regime) and the durable-cursor recovery
+    /// re-applies it after a restart, so eviction degrades liveness of the
+    /// promotion, never safety.
+    pub fn retain_ingress_commit(&mut self, turn_hash: [u8; 32], commit: IngressCommit) {
+        const MAX_RETAINED: usize = 8192;
+        if self.ingress_commits.len() >= MAX_RETAINED {
+            tracing::warn!(
+                retained = self.ingress_commits.len(),
+                "ingress-commit retention full (finalization stalled?); evicting one entry"
+            );
+            if let Some(k) = self.ingress_commits.keys().next().copied() {
+                let _ = self.ingress_commits.remove(&k);
+            }
+        }
+        let _ = self.ingress_commits.insert(turn_hash, commit);
+    }
+
     /// pg-dregg M2: mirror one DURABLY committed turn to postgres.
     ///
     /// Called from the commit path AFTER `commit_finalized_turn` succeeds, with


### PR DESCRIPTION
## Problem: solo finalization double-applies every turn → `nonce replay`, nothing finalizes

On a single-node (solo) devnet, **no turn ever finalizes**. Every finalized turn is
rejected at the blocklace finalization pass with a consistent off-by-one:

```
WARN dregg_node::blocklace_sync: finalized turn rejected (prologue fee may have been
charged as anti-spam; turn NOT accepted) reason=nonce replay: expected 1, got 0
```

Live over a running cave: `executed=0, rejected=25` (every finalized turn), `/status`
`latest_height: 0` vs `dag_height: 136`, every `/api/receipts` entry `finality:
tentative`. The Nth turn of each cell is rejected `expected N, got N-1`, faucet turns
included.

## Root cause — a stale premise, now a double apply

In **solo** mode the `/turns/submit` ingress path applies the turn **authoritatively**:

- it keeps the in-place ledger commit — in `node/src/api.rs`, the
  `if !is_solo { s.ledger.rollback_restore_point(); }` guard is *false* for solo, so the
  actor nonce is advanced; and
- it appends the turn's receipt to the node chain —
  `if is_operator_agent || is_solo { s.cclerk.append_receipt(...) }`.

The turn is then gossiped to the blocklace, which in solo **trivially finalizes every
block** (`blocklace_sync.rs`: "n=1 (solo) tau trivially finalizes every block").
`execute_finalized_turn` (`node/src/blocklace_sync.rs`) re-executes the turn against the
**already-advanced** ledger → the executor's admission prologue sees the cell nonce at N
and the turn carrying N-1 → `nonce replay: expected N, got N-1` → `TurnResult::Rejected`.

The ingress path is written against its own comment:

```
//  * SOLO (n=1) has no finalization pass, so it keeps the in-place commit
//    authoritatively (rolled back only if the receipt-chain append fails).
```

That premise is stale: solo **does** run the blocklace finalization pass now, so the turn
is applied twice (ingress commit + finalized re-execution), and the second apply always
nonce-replays.

## Fix

Make `execute_finalized_turn` **idempotent** for a turn solo ingress already applied: if
we are solo *and* this exact turn (by hash) is already in the node receipt chain, skip
the re-execution instead of double-applying. Scoped to solo so multi-party is untouched —
a foreign client's turn is not in the local chain at finalization (ingress rolled back
and did not append), and the operator's own multi-party turn rolled its ledger back
(nonce not advanced), so both still execute normally.

+38 lines in `node/src/blocklace_sync.rs`, no change to the executor or the multi-party
paths.

## Repro

1. `dregg-node run --data-dir /tmp/solo --port 8899 --enable-faucet` (default
   consensus=blocklace, solo).
2. Submit any signed turn (e.g. faucet-materialize a fresh cell, then an `emit_event`
   turn via `/turns/submit`).
3. Node log → `finalized turn rejected ... nonce replay: expected 1, got 0`; `/status`
   → `latest_height: 0`; the receipt stays `finality: tentative`.

## Validation

The fix is in the node **lib** (`blocklace_sync.rs`) and the lib compiles cleanly on
`upstream/main` + this change. Diagnosis was ground-truthed against a live cave (the
`executed=0, rejected=N` counts, the node-log `nonce replay: expected N, got N-1`, and
`latest_height: 0`). A full end-to-end live run (fresh cave, submit a turn, confirm the
idempotent-skip replaces the rejection) is in progress; `dregg-node`'s **bin** target
currently has one unrelated compile error on `upstream/main` (separate from this fix)
that has to clear first — I'll post the live receipt here when it does.


## Notes / follow-up

- This removes the spurious rejection + double-apply. Solo turns remain `finality:
  tentative` (the honest single-node status — no BFT quorum / attested root, which is
  what `latest_height` tracks; `api.rs` itself notes `latest_height: 0` is "a terrible
  public signal" in solo). If solo should *promote* an ingress-committed receipt
  tentative→final on finalization, that is a natural follow-up (mutate + re-sign the
  chain receipt's `finality`) and is intentionally out of scope for this minimal fix.
- Alternative considered: make ingress roll back in solo too (finalization the sole
  authoritative writer). Rejected as more invasive — it entangles with the solo
  receipt-chain append and the fast-`/api/receipts` optimistic-ingress UX; the
  idempotent-finalization guard is smaller and preserves current ingress behavior.

Found ground-truthing a real multi-agent coordination cave (agents committing verified
turns as their coordination acts) — the tentative-vs-finalized gap is exactly what bites
when you build on "it appears in /api/receipts".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
