### PR TITLE
fix(signer): coordination-exempt join must zero BOTH funding bounds

### DIFF
--- a/dregg-sdk-net/src/bin/dregg-client-sign.rs
+++ b/dregg-sdk-net/src/bin/dregg-client-sign.rs
@@ -91,6 +91,29 @@ fn build_chat_turn(
     turn
 }
 
+/// The cost model the CLIENT estimates its declared `turn.fee` against.
+///
+/// This bin only ever builds a single-action `EmitEvent` turn
+/// ([`build_chat_turn`]), which is exactly dregg's COORDINATION class
+/// ([`Turn::is_coordination`]: EmitEvent-only, no `balance_change`). When the
+/// deployment opts in via `DREGG_COORDINATION_EXEMPT` (truthy — helm forwards it
+/// on the chat send path), the estimate carries `coordination_exempt = true`, so
+/// [`TurnExecutor::estimate_cost`] returns 0 for the class and the client
+/// declares `fee = 0`: the turn rides the node's coordination-exempt admission
+/// free — no cell drain, no faucet grant, no `[unsigned]` throttle. Default OFF =
+/// exact legacy behavior (estimate the full computron cost), so a non-exempt node
+/// still gets a fully-funded fee.
+fn fee_cost_model() -> ComputronCosts {
+    let mut costs = ComputronCosts::default();
+    if env("DREGG_COORDINATION_EXEMPT")
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+    {
+        costs.coordination_exempt = true;
+    }
+    costs
+}
+
 fn env(name: &str) -> Option<String> {
     std::env::var(name).ok().filter(|v| !v.is_empty())
 }
@@ -466,7 +489,9 @@ async fn cmd_send(f: Flags) -> Result<()> {
         &federation_id,
         estimate_nonce,
     );
-    turn.fee = TurnExecutor::new(ComputronCosts::default()).estimate_cost(&turn);
+    // Coordination-aware estimate: `fee = 0` when opted in (this is always an
+    // EmitEvent-only turn), so the send rides dregg's exempt admission free.
+    turn.fee = TurnExecutor::new(fee_cost_model()).estimate_cost(&turn);
 
     // Funding is SEND correctness, not a one-time join convenience. One grant
     // reserves a bounded six-send burst inside the faucet's 60-second window;
@@ -489,7 +514,7 @@ async fn cmd_send(f: Flags) -> Result<()> {
         .await
         .map_err(|e| err(format!("refetch own-cell nonce after funding: {e}")))?;
     turn = build_chat_turn(&clerk, cell, &f.topic, &payload, &federation_id, nonce);
-    turn.fee = TurnExecutor::new(ComputronCosts::default()).estimate_cost(&turn);
+    turn.fee = TurnExecutor::new(fee_cost_model()).estimate_cost(&turn);
     if turn.fee > funding.balance {
         return Err(err(format!(
             "final turn fee {} exceeds the observed funded balance {}",

--- a/dregg-sdk-net/src/bin/dregg-client-sign.rs
+++ b/dregg-sdk-net/src/bin/dregg-client-sign.rs
@@ -16,7 +16,7 @@
 //! Verbs (stdout = exactly one JSON object; progress on stderr):
 //!
 //!   join   ensure the profile exists (create on first use) and its canonical
-//!          agent cell is faucet-materialized on the node — no turn.
+//!          agent cell is faucet-materialized and funded to the requested floor.
 //!   send   commit ONE client-signed turn AS the profile's own cell: an
 //!          `EmitEvent` on the cell (topic = `symbol(--topic)`, data = the
 //!          payload packed 8 bytes/word into the u64-safe low lane) with the
@@ -47,6 +47,10 @@ fn err(msg: String) -> Box<dyn std::error::Error> {
 /// Lean-authoritative state projection enforces for `SetField` lanes.
 const LANE_LO: usize = 24;
 const LANE_BYTES: usize = 8;
+/// The node accepts at most 10,000 computrons in one funded faucet request.
+const FAUCET_MAX_GRANT: u64 = 10_000;
+/// One refill must cover a bounded burst inside the faucet's 60-second per-cell window.
+const SEND_FUNDING_HORIZON: u64 = 6;
 
 fn pack_payload(payload: &[u8]) -> Vec<[u8; 32]> {
     payload
@@ -57,6 +61,34 @@ fn pack_payload(payload: &[u8]) -> Vec<[u8; 32]> {
             word
         })
         .collect()
+}
+
+fn build_chat_turn(
+    clerk: &AgentCipherclerk,
+    cell: dregg_sdk::CellId,
+    topic: &str,
+    payload: &str,
+    federation_id: &[u8; 32],
+    nonce: u64,
+) -> Turn {
+    let effect = Effect::EmitEvent {
+        cell,
+        event: Event {
+            topic: symbol(topic),
+            data: pack_payload(payload.as_bytes()),
+        },
+    };
+    let action = clerk.sign_action_hybrid(
+        dregg_sdk::raw::unsigned_action_named(cell, topic, vec![effect]),
+        federation_id,
+        nonce,
+    );
+    let mut turn = clerk.make_turn_with_actions(vec![action]);
+    turn.agent = cell;
+    turn.nonce = nonce;
+    turn.memo = Some(payload.to_string());
+    turn.valid_until = Some(i64::MAX / 2);
+    turn
 }
 
 fn env(name: &str) -> Option<String> {
@@ -95,9 +127,11 @@ async fn ensure_token(
         return Ok(t);
     }
     let passphrase = env("DREGG_NODE_PASSPHRASE").ok_or_else(|| {
-        err("the node's /turns/submit is bearer-protected: set DREGG_API_TOKEN \
+        err(
+            "the node's /turns/submit is bearer-protected: set DREGG_API_TOKEN \
              (or --token), or DREGG_NODE_PASSPHRASE to unlock"
-            .to_string())
+                .to_string(),
+        )
     })?;
     let raw = http
         .post(format!("{node_url}/api/cipherclerk/unlock"))
@@ -121,46 +155,160 @@ async fn ensure_token(
         .ok_or_else(|| err(format!("unlock returned no bearer_token: {resp}")))
 }
 
-/// Materialize the profile's canonical cell on the node when absent
-/// (`POST /api/faucet` with the public key — a turn cannot conjure its own
-/// agent cell), then poll until visible. Idempotent.
+#[derive(Debug)]
+struct FundingOutcome {
+    materialized: bool,
+    topped_up: bool,
+    joined_in_flight: bool,
+    balance: u64,
+}
+
+fn observed_balance(cell: &serde_json::Value) -> Result<Option<u64>> {
+    if cell.get("found").and_then(|f| f.as_bool()) != Some(true) {
+        return Ok(None);
+    }
+    let balance = cell
+        .get("balance")
+        .and_then(|b| b.as_i64())
+        .ok_or_else(|| err(format!("cell response has no signed balance: {cell}")))?;
+    if balance < 0 {
+        return Err(err(format!(
+            "agent cell has negative balance {balance}; refusing to hide an issuer-well state"
+        )));
+    }
+    Ok(Some(balance as u64))
+}
+
+/// Return whether the cell is absent and how many computrons are required to
+/// make it spendable. `minimum_balance` is the next turn's actual fee; only a
+/// balance below that threshold opens the faucet. When it does, replenish to
+/// `target_balance` so rapid subsequent sends do not hit the 1/min faucet limit.
+fn funding_shortfall(
+    cell: &serde_json::Value,
+    minimum_balance: u64,
+    target_balance: u64,
+) -> Result<(bool, u64)> {
+    if target_balance < minimum_balance {
+        return Err(err(format!(
+            "funding target {target_balance} is below required minimum {minimum_balance}"
+        )));
+    }
+    match observed_balance(cell)? {
+        Some(balance) if balance >= minimum_balance => Ok((false, 0)),
+        Some(balance) => Ok((false, target_balance.saturating_sub(balance))),
+        None => Ok((true, target_balance)),
+    }
+}
+
+async fn wait_for_balance(
+    http: &reqwest::Client,
+    cell_url: &str,
+    target_balance: u64,
+) -> Result<Option<u64>> {
+    for _ in 0..40 {
+        let current = get_json(http, cell_url).await?;
+        if let Some(balance) = observed_balance(&current)?
+            && balance >= target_balance
+        {
+            return Ok(Some(balance));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    Ok(None)
+}
+
+/// Ensure the profile's canonical cell exists and is spendable at
+/// `minimum_balance`. An existing depleted cell is not "done": request enough
+/// from the owner faucet to reach `target_balance`, require a committed faucet
+/// turn for a positive top-up, then poll until the authoritative balance rises.
+/// A rate-limit refusal can mean another owner already submitted the identical
+/// full-mode grant; in that case join the in-flight authority by polling rather
+/// than issuing a duplicate or failing before finalization lands.
 async fn ensure_cell(
     http: &reqwest::Client,
     node_url: &str,
     cell_hex: &str,
     pk_hex: &str,
-    fund: u64,
-) -> Result<bool> {
+    minimum_balance: u64,
+    target_balance: u64,
+) -> Result<FundingOutcome> {
     let cell_url = format!("{node_url}/api/cell/{cell_hex}");
-    let found = |v: &serde_json::Value| v.get("found").and_then(|f| f.as_bool()) == Some(true);
-    if found(&get_json(http, &cell_url).await?) {
-        return Ok(false);
+    let initial = get_json(http, &cell_url).await?;
+    let (materialized, shortfall) = funding_shortfall(&initial, minimum_balance, target_balance)?;
+    if !materialized && shortfall == 0 {
+        return Ok(FundingOutcome {
+            materialized: false,
+            topped_up: false,
+            joined_in_flight: false,
+            balance: observed_balance(&initial)?.expect("existing cell has a balance"),
+        });
     }
-    let resp: serde_json::Value = http
+
+    let raw = http
         .post(format!("{node_url}/api/faucet"))
         .json(&serde_json::json!({
             "recipient": cell_hex,
-            "amount": fund,
+            "amount": shortfall,
             "public_key": pk_hex,
         }))
         .send()
         .await
-        .map_err(|e| err(format!("POST /api/faucet: {e}")))?
-        .json()
+        .map_err(|e| err(format!("POST /api/faucet: {e}")))?;
+    let status = raw.status();
+    let body = raw
+        .text()
         .await
-        .map_err(|e| err(format!("parse faucet response: {e}")))?;
-    if resp.get("success").and_then(|s| s.as_bool()) != Some(true) {
-        return Err(err(format!("faucet refused cell materialization: {resp}")));
+        .map_err(|e| err(format!("read faucet response: {e}")))?;
+    if !status.is_success() {
+        return Err(err(format!("POST /api/faucet returned {status}: {body}")));
     }
-    eprintln!("[client-sign] faucet materialized cell (+{fund} computrons)");
-    for _ in 0..40 {
-        if found(&get_json(http, &cell_url).await?) {
-            return Ok(true);
+    let resp: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|e| err(format!("parse faucet response (HTTP {status}): {e}")))?;
+    if resp.get("success").and_then(|s| s.as_bool()) != Some(true) {
+        let reason = resp
+            .get("error")
+            .and_then(|e| e.as_str())
+            .unwrap_or_default();
+        if shortfall > 0 && reason.starts_with("rate limited") {
+            if let Some(balance) = wait_for_balance(http, &cell_url, target_balance).await? {
+                eprintln!(
+                    "[client-sign] joined an in-flight faucet grant; balance reached {balance}"
+                );
+                return Ok(FundingOutcome {
+                    materialized: false,
+                    topped_up: false,
+                    joined_in_flight: true,
+                    balance,
+                });
+            }
+            return Err(err(format!(
+                "faucet grant was already in flight but cell {cell_hex} did not reach {target_balance} computrons within 10s: {resp}"
+            )));
         }
-        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        return Err(err(format!("faucet refused funding: {resp}")));
+    }
+    if shortfall > 0 && resp.get("turn_hash").and_then(|h| h.as_str()).is_none() {
+        return Err(err(format!(
+            "faucet reported success for +{shortfall} computrons without a committed turn_hash: {resp}"
+        )));
+    }
+
+    let action = if materialized {
+        "materialized"
+    } else {
+        "topped up"
+    };
+    eprintln!("[client-sign] faucet {action} cell (+{shortfall} computrons)");
+    if let Some(balance) = wait_for_balance(http, &cell_url, target_balance).await? {
+        return Ok(FundingOutcome {
+            materialized,
+            topped_up: !materialized && shortfall > 0,
+            joined_in_flight: false,
+            balance,
+        });
     }
     Err(err(format!(
-        "cell {cell_hex} not visible on the node 10s after faucet accept"
+        "cell {cell_hex} did not reach the {target_balance}-computron funding target within 10s after faucet accept"
     )))
 }
 
@@ -183,7 +331,8 @@ fn resolve_clerk(profile_flag: Option<&str>, create: bool) -> Result<(String, Ag
                 profiles::profiles_dir().display()
             )));
         }
-        let info = profiles::create(&name).map_err(|e| err(format!("create profile '{name}': {e}")))?;
+        let info =
+            profiles::create(&name).map_err(|e| err(format!("create profile '{name}': {e}")))?;
         eprintln!(
             "[client-sign] created identity '{name}' (pubkey {})",
             info.public_key_hex
@@ -243,9 +392,9 @@ fn parse_flags(argv: Vec<String>) -> Result<Flags> {
 
 const USAGE: &str = "dregg-client-sign: commit CLIENT-SIGNED turns to a dregg node as a named profile\n\n\
   join [--profile P] [--node-url U] [--fund N]\n\
-       ensure the profile identity + its faucet-materialized cell (no turn)\n\
-  send [--profile P] [--node-url U] [--token T] [--topic S] [--to CELL_HEX] PAYLOAD...\n\
-       ONE hybrid-signed EmitEvent turn as the profile's own cell; payload\n\
+       ensure the profile identity + a cell funded to at least N computrons\n\
+  send [--profile P] [--node-url U] [--token T] [--fund N] [--topic S] [--to CELL_HEX] PAYLOAD...\n\
+       ensure at least N computrons, then commit ONE hybrid-signed EmitEvent; payload\n\
        rides in the signed turn (memo + event data words)\n\n\
 env (flags win): DREGG_NODE_URL, DREGG_API_TOKEN (or DREGG_NODE_PASSPHRASE\n\
 to unlock), DREGG_PROFILE (the SDK's active-profile convention)";
@@ -255,7 +404,7 @@ async fn cmd_join(f: Flags) -> Result<()> {
     let (name, clerk) = resolve_clerk(f.profile.as_deref(), true)?;
     let cell_hex = hex::encode(clerk.cell_id("default").as_bytes());
     let pk_hex = hex::encode(clerk.public_key().0);
-    let materialized = ensure_cell(&http, &f.node_url, &cell_hex, &pk_hex, f.fund).await?;
+    let funding = ensure_cell(&http, &f.node_url, &cell_hex, &pk_hex, f.fund, f.fund).await?;
     println!(
         "{}",
         serde_json::json!({
@@ -264,7 +413,10 @@ async fn cmd_join(f: Flags) -> Result<()> {
             "profile": name,
             "public_key": pk_hex,
             "cell": cell_hex,
-            "materialized": materialized,
+            "materialized": funding.materialized,
+            "topped_up": funding.topped_up,
+            "joined_in_flight": funding.joined_in_flight,
+            "balance": funding.balance,
         })
     );
     Ok(())
@@ -292,49 +444,63 @@ async fn cmd_send(f: Flags) -> Result<()> {
         }
     }
 
-    let bearer = ensure_token(&http, &f.node_url, f.token.clone()).await?;
-    let cell_state = get_json(&http, &format!("{}/api/cell/{cell_hex}", f.node_url)).await?;
-    if cell_state.get("found").and_then(|v| v.as_bool()) != Some(true) {
-        return Err(err(format!(
-            "cell {cell_hex} not on the node — run `dregg-client-sign join` first"
-        )));
-    }
+    // Materialize first without consuming the funded faucet bucket. The zero-
+    // amount path is explicitly outside the per-cell 1/min limit, so a brand-new
+    // profile can immediately receive the fee-sized positive top-up below.
+    let pk_hex = hex::encode(clerk.public_key().0);
+    let presence = ensure_cell(&http, &f.node_url, &cell_hex, &pk_hex, 0, 0).await?;
 
     let federation_id = node
         .fetch_executor_federation_id()
         .await
         .map_err(|e| err(format!("fetch executor federation id: {e}")))?;
+    let estimate_nonce = node
+        .fetch_cell_nonce(&cell)
+        .await
+        .map_err(|e| err(format!("fetch own-cell nonce for fee estimate: {e}")))?;
+    let mut turn = build_chat_turn(
+        &clerk,
+        cell,
+        &f.topic,
+        &payload,
+        &federation_id,
+        estimate_nonce,
+    );
+    turn.fee = TurnExecutor::new(ComputronCosts::default()).estimate_cost(&turn);
+
+    // Funding is SEND correctness, not a one-time join convenience. One grant
+    // reserves a bounded six-send burst inside the faucet's 60-second window;
+    // cap the requested delta to the node's 10,000-computron per-request law.
+    let desired = f.fund.max(turn.fee.saturating_mul(SEND_FUNDING_HORIZON));
+    let target = desired.min(presence.balance.saturating_add(FAUCET_MAX_GRANT));
+    if target < turn.fee {
+        return Err(err(format!(
+            "turn fee {} exceeds the current balance {} plus the faucet's {}-computron grant cap",
+            turn.fee, presence.balance, FAUCET_MAX_GRANT
+        )));
+    }
+    let funding = ensure_cell(&http, &f.node_url, &cell_hex, &pk_hex, turn.fee, target).await?;
+
+    // Funding can wait up to 10s and another same-profile sender can commit in
+    // that window. Refetch the nonce immediately before signing, then rebuild
+    // the action because dregg-action-sig-v3 binds that nonce.
     let nonce = node
         .fetch_cell_nonce(&cell)
         .await
-        .map_err(|e| err(format!("fetch own-cell nonce: {e}")))?;
-    let chain_head = node
+        .map_err(|e| err(format!("refetch own-cell nonce after funding: {e}")))?;
+    turn = build_chat_turn(&clerk, cell, &f.topic, &payload, &federation_id, nonce);
+    turn.fee = TurnExecutor::new(ComputronCosts::default()).estimate_cost(&turn);
+    if turn.fee > funding.balance {
+        return Err(err(format!(
+            "final turn fee {} exceeds the observed funded balance {}",
+            turn.fee, funding.balance
+        )));
+    }
+    turn.previous_receipt_hash = node
         .fetch_chain_head()
         .await
-        .map_err(|e| err(format!("fetch chain head: {e}")))?;
-
-    let effect = Effect::EmitEvent {
-        cell,
-        event: Event {
-            topic: symbol(&f.topic),
-            data: pack_payload(payload.as_bytes()),
-        },
-    };
-    // Sign the action over the nonce the turn will CARRY (the on-ledger
-    // nonce): the dregg-action-sig-v3 message binds the turn nonce, and
-    // signing over anything local goes stale after the profile's first turn.
-    let action = clerk.sign_action_hybrid(
-        dregg_sdk::raw::unsigned_action_named(cell, &f.topic, vec![effect]),
-        &federation_id,
-        nonce,
-    );
-    let mut turn: Turn = clerk.make_turn_with_actions(vec![action]);
-    turn.agent = cell;
-    turn.nonce = nonce;
-    turn.memo = Some(payload.clone());
-    turn.valid_until = Some(i64::MAX / 2);
-    turn.previous_receipt_hash = chain_head;
-    turn.fee = TurnExecutor::new(ComputronCosts::default()).estimate_cost(&turn);
+        .map_err(|e| err(format!("fetch chain head after funding: {e}")))?;
+    let bearer = ensure_token(&http, &f.node_url, f.token.clone()).await?;
 
     let signed = clerk.sign_turn(&turn);
     let bytes =
@@ -388,6 +554,10 @@ async fn cmd_send(f: Flags) -> Result<()> {
                     "profile": name,
                     "agent_cell": cell_hex,
                     "to": cell_hex,
+                    "materialized": presence.materialized,
+                    "topped_up": funding.topped_up,
+                    "joined_in_flight": funding.joined_in_flight,
+                    "balance_before_send": funding.balance,
                     "topic": f.topic,
                     "payload": payload,
                     "turn_hash": turn_hash,
@@ -434,5 +604,365 @@ async fn main() {
     if let Err(e) = run.await {
         eprintln!("[client-sign] error: {e}");
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use dregg_cell::{AuthRequired, Cell, CellId, Ledger, Permissions};
+    use dregg_turn::{Action, Authorization, CallForest, DelegationMode, TurnResult, turn::Turn};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::sync::Mutex;
+
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    enum FaucetMode {
+        Commit,
+        RateLimitedThenCommit,
+    }
+
+    struct FaucetNode {
+        ledger: Ledger,
+        faucet: CellId,
+        recipient: CellId,
+        calls: u64,
+        mode: FaucetMode,
+    }
+
+    fn open_permissions() -> Permissions {
+        Permissions {
+            send: AuthRequired::None,
+            receive: AuthRequired::None,
+            set_state: AuthRequired::None,
+            set_permissions: AuthRequired::None,
+            set_verification_key: AuthRequired::None,
+            increment_nonce: AuthRequired::None,
+            delegate: AuthRequired::None,
+            access: AuthRequired::None,
+        }
+    }
+
+    fn test_node(balance: i64, mode: FaucetMode) -> FaucetNode {
+        let mut faucet = Cell::with_balance([1; 32], [0; 32], 1_000_000);
+        faucet.permissions = open_permissions();
+        let faucet_id = faucet.id();
+        let mut recipient = Cell::with_balance([2; 32], [0; 32], balance);
+        recipient.permissions = open_permissions();
+        let recipient_id = recipient.id();
+        let mut ledger = Ledger::new();
+        ledger.insert_cell(faucet).unwrap();
+        ledger.insert_cell(recipient).unwrap();
+        FaucetNode {
+            ledger,
+            faucet: faucet_id,
+            recipient: recipient_id,
+            calls: 0,
+            mode,
+        }
+    }
+
+    fn transfer_turn(node: &FaucetNode, amount: u64) -> Turn {
+        let mut forest = CallForest::new();
+        forest.add_root(Action {
+            target: node.faucet,
+            method: *blake3::hash(b"faucet_transfer").as_bytes(),
+            args: vec![],
+            authorization: Authorization::Unchecked,
+            preconditions: Default::default(),
+            effects: vec![Effect::Transfer {
+                from: node.faucet,
+                to: node.recipient,
+                amount,
+            }],
+            may_delegate: DelegationMode::None,
+            commitment_mode: Default::default(),
+            balance_change: None,
+            witness_blobs: vec![],
+        });
+        Turn {
+            agent: node.faucet,
+            nonce: node
+                .ledger
+                .get(&node.faucet)
+                .expect("faucet cell")
+                .state
+                .nonce(),
+            fee: 0,
+            memo: None,
+            valid_until: Some(1_000_000),
+            call_forest: forest,
+            depends_on: vec![],
+            previous_receipt_hash: None,
+            conservation_proof: None,
+            sovereign_witnesses: Default::default(),
+            execution_proof: None,
+            execution_proof_cell: None,
+            execution_proof_new_commitment: None,
+            custom_program_proofs: None,
+            effect_binding_proofs: Vec::new(),
+            cross_effect_dependencies: Vec::new(),
+            effect_witness_index_map: Vec::new(),
+        }
+    }
+
+    fn commit_top_up(node: &mut FaucetNode, amount: u64) -> serde_json::Value {
+        let turn = transfer_turn(node, amount);
+        let hash = hex::encode(turn.hash());
+        node.calls += 1;
+        match TurnExecutor::new(ComputronCosts::zero()).execute(&turn, &mut node.ledger) {
+            TurnResult::Committed { .. } => {
+                serde_json::json!({"success": true, "turn_hash": hash})
+            }
+            other => serde_json::json!({"success": false, "error": format!("{other:?}")}),
+        }
+    }
+
+    async fn handle_connection(mut socket: tokio::net::TcpStream, state: Arc<Mutex<FaucetNode>>) {
+        let mut request = Vec::new();
+        let mut chunk = [0u8; 4096];
+        let header_end = loop {
+            let Ok(n) = socket.read(&mut chunk).await else {
+                return;
+            };
+            if n == 0 {
+                return;
+            }
+            request.extend_from_slice(&chunk[..n]);
+            if let Some(i) = request.windows(4).position(|w| w == b"\r\n\r\n") {
+                break i + 4;
+            }
+        };
+        let headers = String::from_utf8_lossy(&request[..header_end]).to_string();
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                line.to_ascii_lowercase()
+                    .strip_prefix("content-length:")
+                    .and_then(|n| n.trim().parse::<usize>().ok())
+            })
+            .unwrap_or(0);
+        while request.len() < header_end + content_length {
+            let Ok(n) = socket.read(&mut chunk).await else {
+                return;
+            };
+            if n == 0 {
+                return;
+            }
+            request.extend_from_slice(&chunk[..n]);
+        }
+        let request_line = headers.lines().next().unwrap_or_default();
+        let body = &request[header_end..header_end + content_length];
+        let response = if request_line.starts_with("GET /api/cell/") {
+            let node = state.lock().await;
+            let balance = node
+                .ledger
+                .get(&node.recipient)
+                .expect("recipient cell")
+                .state
+                .balance();
+            serde_json::json!({"found": true, "balance": balance})
+        } else if request_line.starts_with("POST /api/faucet ") {
+            let amount = serde_json::from_slice::<serde_json::Value>(body)
+                .ok()
+                .and_then(|v| v.get("amount").and_then(|n| n.as_u64()))
+                .unwrap_or(0);
+            let mode = state.lock().await.mode;
+            match mode {
+                FaucetMode::Commit => {
+                    let mut node = state.lock().await;
+                    commit_top_up(&mut node, amount)
+                }
+                FaucetMode::RateLimitedThenCommit => {
+                    state.lock().await.calls += 1;
+                    let shared = state.clone();
+                    tokio::spawn(async move {
+                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                        let mut node = shared.lock().await;
+                        node.calls -= 1;
+                        let _ = commit_top_up(&mut node, amount);
+                    });
+                    serde_json::json!({
+                        "success": false,
+                        "error": "rate limited: 1 request per cell per minute"
+                    })
+                }
+            }
+        } else {
+            serde_json::json!({"error": "not found"})
+        };
+        let bytes = serde_json::to_vec(&response).unwrap();
+        let head = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            bytes.len()
+        );
+        let _ = socket.write_all(head.as_bytes()).await;
+        let _ = socket.write_all(&bytes).await;
+    }
+
+    async fn spawn_faucet_node(
+        balance: i64,
+        mode: FaucetMode,
+    ) -> (String, Arc<Mutex<FaucetNode>>, tokio::task::JoinHandle<()>) {
+        let state = Arc::new(Mutex::new(test_node(balance, mode)));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let shared = state.clone();
+        let handle = tokio::spawn(async move {
+            while let Ok((socket, _)) = listener.accept().await {
+                tokio::spawn(handle_connection(socket, shared.clone()));
+            }
+        });
+        (url, state, handle)
+    }
+
+    fn real_chat_turn(agent: CellId, payload: &[u8]) -> Turn {
+        let mut forest = CallForest::new();
+        forest.add_root(Action {
+            target: agent,
+            method: *blake3::hash(b"helm.chat").as_bytes(),
+            args: vec![],
+            authorization: Authorization::Unchecked,
+            preconditions: Default::default(),
+            effects: vec![Effect::EmitEvent {
+                cell: agent,
+                event: Event {
+                    topic: symbol("helm.chat"),
+                    data: pack_payload(payload),
+                },
+            }],
+            may_delegate: DelegationMode::None,
+            commitment_mode: Default::default(),
+            balance_change: None,
+            witness_blobs: vec![],
+        });
+        let mut turn = Turn {
+            agent,
+            nonce: 0,
+            fee: 0,
+            memo: Some(String::from_utf8(payload.to_vec()).unwrap()),
+            valid_until: Some(1_000_000),
+            call_forest: forest,
+            depends_on: vec![],
+            previous_receipt_hash: None,
+            conservation_proof: None,
+            sovereign_witnesses: Default::default(),
+            execution_proof: None,
+            execution_proof_cell: None,
+            execution_proof_new_commitment: None,
+            custom_program_proofs: None,
+            effect_binding_proofs: Vec::new(),
+            cross_effect_dependencies: Vec::new(),
+            effect_witness_index_map: Vec::new(),
+        };
+        turn.fee = TurnExecutor::new(ComputronCosts::default()).estimate_cost(&turn);
+        turn
+    }
+
+    #[test]
+    fn existing_low_balance_cell_requests_six_send_horizon() {
+        let cell = serde_json::json!({"found": true, "balance": 90});
+        assert_eq!(
+            funding_shortfall(&cell, 1_510, 9_060).unwrap(),
+            (false, 8_970)
+        );
+    }
+
+    #[test]
+    fn affordable_burst_send_does_not_reopen_rate_limited_faucet() {
+        let cell = serde_json::json!({"found": true, "balance": 3_490});
+        assert_eq!(funding_shortfall(&cell, 1_510, 9_060).unwrap(), (false, 0));
+    }
+
+    #[test]
+    fn absent_cell_receives_the_full_funding_target() {
+        let cell = serde_json::json!({"found": false, "balance": 0});
+        assert_eq!(
+            funding_shortfall(&cell, 1_510, 9_060).unwrap(),
+            (true, 9_060)
+        );
+    }
+
+    #[test]
+    fn negative_agent_balance_refuses_instead_of_masking_an_issuer_well() {
+        let cell = serde_json::json!({"found": true, "balance": -1});
+        let error = funding_shortfall(&cell, 1_510, 9_060)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("negative balance -1"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn low_balance_http_top_up_commits_and_enables_real_chat_turn() {
+        let (url, state, handle) = spawn_faucet_node(90, FaucetMode::Commit).await;
+        let (cell_hex, pk_hex, recipient) = {
+            let node = state.lock().await;
+            (
+                hex::encode(node.recipient.0),
+                hex::encode(node.ledger.get(&node.recipient).unwrap().public_key()),
+                node.recipient,
+            )
+        };
+        let payload = b"This chat-sized send must fail before funding and commit after the HTTP faucet top-up.";
+        let turn = real_chat_turn(recipient, payload);
+        assert!(turn.fee > 90 && turn.fee < 9_060);
+        let mut depleted = state.lock().await.ledger.clone();
+        let pre = TurnExecutor::new(ComputronCosts::default()).execute(&turn, &mut depleted);
+        assert!(
+            !pre.is_committed(),
+            "must-fail-pre: the depleted real ledger must reject this exact chat turn: {pre:?}"
+        );
+
+        let http = reqwest::Client::new();
+        let outcome = ensure_cell(&http, &url, &cell_hex, &pk_hex, 1_510, 9_060)
+            .await
+            .expect("existing low-balance cell must top up");
+        assert!(outcome.topped_up);
+        assert_eq!(outcome.balance, 9_060);
+        let mut node = state.lock().await;
+        assert_eq!(node.calls, 1, "the product path must call the faucet once");
+        assert_eq!(
+            node.ledger.get(&recipient).unwrap().state.balance(),
+            9_060,
+            "the committed HTTP top-up must raise the real ledger balance"
+        );
+        let result = TurnExecutor::new(ComputronCosts::default()).execute(&turn, &mut node.ledger);
+        assert!(
+            result.is_committed(),
+            "the exact next metered chat turn must commit: {result:?}"
+        );
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn rate_limited_duplicate_joins_in_flight_grant() {
+        let (url, state, handle) = spawn_faucet_node(90, FaucetMode::RateLimitedThenCommit).await;
+        let (cell_hex, pk_hex) = {
+            let node = state.lock().await;
+            (
+                hex::encode(node.recipient.0),
+                hex::encode(node.ledger.get(&node.recipient).unwrap().public_key()),
+            )
+        };
+        let outcome = ensure_cell(
+            &reqwest::Client::new(),
+            &url,
+            &cell_hex,
+            &pk_hex,
+            1_510,
+            9_060,
+        )
+        .await
+        .expect("duplicate owner must join the in-flight grant");
+        assert!(outcome.joined_in_flight);
+        assert_eq!(outcome.balance, 9_060);
+        assert_eq!(state.lock().await.calls, 1);
+        handle.abort();
     }
 }

--- a/dregg-sdk-net/src/bin/dregg-client-sign.rs
+++ b/dregg-sdk-net/src/bin/dregg-client-sign.rs
@@ -408,6 +408,15 @@ async fn cmd_send(f: Flags) -> Result<()> {
 
 #[tokio::main]
 async fn main() {
+    // Route this process's ML-DSA through the Lean-verified cores exported by
+    // the linked archive (once-per-process, the same install the node and the
+    // SDK agent-runtime perform). Without it dregg-pq's audit gate ABORTS the
+    // first hybrid sign rather than silently running the unaudited `fips204`
+    // crate — the gate is right, the host must install.
+    let sign_core = dregg_sdk::install_verified_mldsa_sign_core_real();
+    let verify_core = dregg_sdk::install_verified_mldsa_verify_core();
+    eprintln!("[client-sign] verified ML-DSA cores: sign {sign_core:?}, verify {verify_core:?}");
+
     let mut argv: Vec<String> = std::env::args().skip(1).collect();
     if argv.is_empty() {
         eprintln!("{USAGE}");

--- a/dregg-sdk-net/src/bin/dregg-client-sign.rs
+++ b/dregg-sdk-net/src/bin/dregg-client-sign.rs
@@ -1,0 +1,429 @@
+//! `dregg-client-sign` — the SDK-side reference CLIENT-SIGN tool.
+//!
+//! One small binary that lets any subprocess-capable harness commit a REAL
+//! client-signed turn to a dregg node without linking the SDK itself: load a
+//! named `~/.dregg/profiles/` identity, build a single-action `EmitEvent`
+//! turn carrying an opaque payload, hybrid-sign it (Ed25519 + ML-DSA-65 over
+//! the same turn bytes — the deployed `require_pq` posture), and POST the
+//! postcard `SignedTurn` to the node's client-signed ingress `/turns/submit`.
+//!
+//! Why a bin HERE and not a `dregg turn` verb: the CLI crate is deliberately
+//! SDK-free ("Lean-free and cross-platform clean", cli/Cargo.toml) and its own
+//! turn module documents that the signed-envelope path belongs to the SDK.
+//! `dregg-sdk-net` IS the networked SDK layer — every dependency this tool
+//! needs is already in the crate's graph, so the whole surface is this file.
+//!
+//! Verbs (stdout = exactly one JSON object; progress on stderr):
+//!
+//!   join   ensure the profile exists (create on first use) and its canonical
+//!          agent cell is faucet-materialized on the node — no turn.
+//!   send   commit ONE client-signed turn AS the profile's own cell: an
+//!          `EmitEvent` on the cell (topic = `symbol(--topic)`, data = the
+//!          payload packed 8 bytes/word into the u64-safe low lane) with the
+//!          full payload string as the turn memo (length-prefixed into
+//!          `Turn::hash`, so the signature binds it). Exit 0 only when the
+//!          node has receipted the turn.
+//!
+//! Env (flags win): DREGG_NODE_URL (default http://127.0.0.1:8899),
+//! DREGG_API_TOKEN (bearer for the protected ingress) or DREGG_NODE_PASSPHRASE
+//! (unlock fallback), DREGG_PROFILE / the profiles `ACTIVE` file (the SDK's
+//! own active-profile convention) when `--profile` is not given.
+
+use dregg_sdk::AgentCipherclerk;
+use dregg_sdk::profiles;
+use dregg_sdk_net::NodeHttpClient;
+use dregg_turn::action::{Effect, Event, symbol};
+use dregg_turn::{ComputronCosts, Turn, TurnExecutor};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+fn err(msg: String) -> Box<dyn std::error::Error> {
+    msg.into()
+}
+
+/// The low-lane payload packing: 8 bytes per 32-byte word, in `word[24..32]`.
+/// A value confined to the low 8 bytes is a valid element of ANY field the
+/// executors interpret words in (< 2^64), the same discipline the node's
+/// Lean-authoritative state projection enforces for `SetField` lanes.
+const LANE_LO: usize = 24;
+const LANE_BYTES: usize = 8;
+
+fn pack_payload(payload: &[u8]) -> Vec<[u8; 32]> {
+    payload
+        .chunks(LANE_BYTES)
+        .map(|chunk| {
+            let mut word = [0u8; 32];
+            word[LANE_LO..LANE_LO + chunk.len()].copy_from_slice(chunk);
+            word
+        })
+        .collect()
+}
+
+fn env(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.is_empty())
+}
+
+fn node_url_default() -> String {
+    env("DREGG_NODE_URL").unwrap_or_else(|| "http://127.0.0.1:8899".to_string())
+}
+
+async fn get_json(http: &reqwest::Client, url: &str) -> Result<serde_json::Value> {
+    let resp = http
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| err(format!("GET {url}: {e}")))?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(err(format!("GET {url} returned {status}")));
+    }
+    resp.json()
+        .await
+        .map_err(|e| err(format!("parse {url}: {e}")))
+}
+
+/// The bearer for the node's protected write surface: `--token` /
+/// `DREGG_API_TOKEN` directly, else unlock with `DREGG_NODE_PASSPHRASE`
+/// (`POST /api/cipherclerk/unlock` — never a blind `.json()`: the node's
+/// rate-limited 429 carries an empty body).
+async fn ensure_token(
+    http: &reqwest::Client,
+    node_url: &str,
+    token_flag: Option<String>,
+) -> Result<String> {
+    if let Some(t) = token_flag.or_else(|| env("DREGG_API_TOKEN")) {
+        return Ok(t);
+    }
+    let passphrase = env("DREGG_NODE_PASSPHRASE").ok_or_else(|| {
+        err("the node's /turns/submit is bearer-protected: set DREGG_API_TOKEN \
+             (or --token), or DREGG_NODE_PASSPHRASE to unlock"
+            .to_string())
+    })?;
+    let raw = http
+        .post(format!("{node_url}/api/cipherclerk/unlock"))
+        .json(&serde_json::json!({ "passphrase": passphrase }))
+        .send()
+        .await
+        .map_err(|e| err(format!("POST /api/cipherclerk/unlock: {e}")))?;
+    let status = raw.status();
+    let body = raw
+        .text()
+        .await
+        .map_err(|e| err(format!("read unlock response: {e}")))?;
+    if !status.is_success() {
+        return Err(err(format!("unlock returned {status}: {body}")));
+    }
+    let resp: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|e| err(format!("parse unlock response (HTTP {status}): {e}")))?;
+    resp.get("bearer_token")
+        .and_then(|t| t.as_str())
+        .map(String::from)
+        .ok_or_else(|| err(format!("unlock returned no bearer_token: {resp}")))
+}
+
+/// Materialize the profile's canonical cell on the node when absent
+/// (`POST /api/faucet` with the public key — a turn cannot conjure its own
+/// agent cell), then poll until visible. Idempotent.
+async fn ensure_cell(
+    http: &reqwest::Client,
+    node_url: &str,
+    cell_hex: &str,
+    pk_hex: &str,
+    fund: u64,
+) -> Result<bool> {
+    let cell_url = format!("{node_url}/api/cell/{cell_hex}");
+    let found = |v: &serde_json::Value| v.get("found").and_then(|f| f.as_bool()) == Some(true);
+    if found(&get_json(http, &cell_url).await?) {
+        return Ok(false);
+    }
+    let resp: serde_json::Value = http
+        .post(format!("{node_url}/api/faucet"))
+        .json(&serde_json::json!({
+            "recipient": cell_hex,
+            "amount": fund,
+            "public_key": pk_hex,
+        }))
+        .send()
+        .await
+        .map_err(|e| err(format!("POST /api/faucet: {e}")))?
+        .json()
+        .await
+        .map_err(|e| err(format!("parse faucet response: {e}")))?;
+    if resp.get("success").and_then(|s| s.as_bool()) != Some(true) {
+        return Err(err(format!("faucet refused cell materialization: {resp}")));
+    }
+    eprintln!("[client-sign] faucet materialized cell (+{fund} computrons)");
+    for _ in 0..40 {
+        if found(&get_json(http, &cell_url).await?) {
+            return Ok(true);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    Err(err(format!(
+        "cell {cell_hex} not visible on the node 10s after faucet accept"
+    )))
+}
+
+/// `--profile` flag → `DREGG_PROFILE` / `ACTIVE` (the SDK's own convention).
+/// A SIGNER never guesses further: no profile configured is a hard error.
+fn resolve_clerk(profile_flag: Option<&str>, create: bool) -> Result<(String, AgentCipherclerk)> {
+    let name = match profile_flag {
+        Some(p) => p.to_string(),
+        None => profiles::active_name().ok_or_else(|| {
+            err("no identity: pass --profile, or set DREGG_PROFILE / `dregg id use`".to_string())
+        })?,
+    };
+    let exists = profiles::list()
+        .map(|ps| ps.iter().any(|p| p.name == name))
+        .unwrap_or(false);
+    if !exists {
+        if !create {
+            return Err(err(format!(
+                "profile '{name}' not found in {} — run `join` (or `dregg id create`) first",
+                profiles::profiles_dir().display()
+            )));
+        }
+        let info = profiles::create(&name).map_err(|e| err(format!("create profile '{name}': {e}")))?;
+        eprintln!(
+            "[client-sign] created identity '{name}' (pubkey {})",
+            info.public_key_hex
+        );
+    }
+    let clerk = profiles::load(&name).map_err(|e| err(format!("load profile '{name}': {e}")))?;
+    Ok((name, clerk))
+}
+
+struct Flags {
+    node_url: String,
+    profile: Option<String>,
+    token: Option<String>,
+    topic: String,
+    to: Option<String>,
+    fund: u64,
+    rest: Vec<String>,
+}
+
+fn parse_flags(argv: Vec<String>) -> Result<Flags> {
+    let mut f = Flags {
+        node_url: node_url_default(),
+        profile: None,
+        token: None,
+        topic: "client-sign".to_string(),
+        to: None,
+        fund: 5000,
+        rest: Vec::new(),
+    };
+    let mut it = argv.into_iter();
+    while let Some(flag) = it.next() {
+        let mut val = |name: &str| {
+            it.next()
+                .ok_or_else(|| err(format!("{name} requires a value")))
+        };
+        match flag.as_str() {
+            "--node-url" => f.node_url = val("--node-url")?,
+            "--profile" => f.profile = Some(val("--profile")?),
+            "--token" => f.token = Some(val("--token")?),
+            "--topic" => f.topic = val("--topic")?,
+            "--to" => f.to = Some(val("--to")?),
+            "--fund" => {
+                f.fund = val("--fund")?
+                    .parse()
+                    .map_err(|e| err(format!("--fund must be a u64: {e}")))?
+            }
+            "--help" | "-h" => {
+                eprintln!("{USAGE}");
+                std::process::exit(0);
+            }
+            other => f.rest.push(other.to_string()),
+        }
+    }
+    f.node_url = f.node_url.trim_end_matches('/').to_string();
+    Ok(f)
+}
+
+const USAGE: &str = "dregg-client-sign: commit CLIENT-SIGNED turns to a dregg node as a named profile\n\n\
+  join [--profile P] [--node-url U] [--fund N]\n\
+       ensure the profile identity + its faucet-materialized cell (no turn)\n\
+  send [--profile P] [--node-url U] [--token T] [--topic S] [--to CELL_HEX] PAYLOAD...\n\
+       ONE hybrid-signed EmitEvent turn as the profile's own cell; payload\n\
+       rides in the signed turn (memo + event data words)\n\n\
+env (flags win): DREGG_NODE_URL, DREGG_API_TOKEN (or DREGG_NODE_PASSPHRASE\n\
+to unlock), DREGG_PROFILE (the SDK's active-profile convention)";
+
+async fn cmd_join(f: Flags) -> Result<()> {
+    let http = reqwest::Client::new();
+    let (name, clerk) = resolve_clerk(f.profile.as_deref(), true)?;
+    let cell_hex = hex::encode(clerk.cell_id("default").as_bytes());
+    let pk_hex = hex::encode(clerk.public_key().0);
+    let materialized = ensure_cell(&http, &f.node_url, &cell_hex, &pk_hex, f.fund).await?;
+    println!(
+        "{}",
+        serde_json::json!({
+            "joined": true,
+            "node": f.node_url,
+            "profile": name,
+            "public_key": pk_hex,
+            "cell": cell_hex,
+            "materialized": materialized,
+        })
+    );
+    Ok(())
+}
+
+async fn cmd_send(f: Flags) -> Result<()> {
+    if f.rest.is_empty() {
+        return Err(err("send requires a payload".to_string()));
+    }
+    let payload = f.rest.join(" ");
+    let http = reqwest::Client::new();
+    let node = NodeHttpClient::new(&f.node_url);
+    let (name, clerk) = resolve_clerk(f.profile.as_deref(), false)?;
+    let cell = clerk.cell_id("default");
+    let cell_hex = hex::encode(cell.as_bytes());
+
+    // This tool SIGNS AS the profile — the only admissible target is the
+    // profile's own cell (the node derives agent == the signer's cell).
+    if let Some(to) = &f.to {
+        if to.to_lowercase() != cell_hex {
+            return Err(err(format!(
+                "--to {to} is not profile '{name}'s own cell {cell_hex} — \
+                 a client-signed turn can only act as the signer's cell"
+            )));
+        }
+    }
+
+    let bearer = ensure_token(&http, &f.node_url, f.token.clone()).await?;
+    let cell_state = get_json(&http, &format!("{}/api/cell/{cell_hex}", f.node_url)).await?;
+    if cell_state.get("found").and_then(|v| v.as_bool()) != Some(true) {
+        return Err(err(format!(
+            "cell {cell_hex} not on the node — run `dregg-client-sign join` first"
+        )));
+    }
+
+    let federation_id = node
+        .fetch_executor_federation_id()
+        .await
+        .map_err(|e| err(format!("fetch executor federation id: {e}")))?;
+    let nonce = node
+        .fetch_cell_nonce(&cell)
+        .await
+        .map_err(|e| err(format!("fetch own-cell nonce: {e}")))?;
+    let chain_head = node
+        .fetch_chain_head()
+        .await
+        .map_err(|e| err(format!("fetch chain head: {e}")))?;
+
+    let effect = Effect::EmitEvent {
+        cell,
+        event: Event {
+            topic: symbol(&f.topic),
+            data: pack_payload(payload.as_bytes()),
+        },
+    };
+    // Sign the action over the nonce the turn will CARRY (the on-ledger
+    // nonce): the dregg-action-sig-v3 message binds the turn nonce, and
+    // signing over anything local goes stale after the profile's first turn.
+    let action = clerk.sign_action_hybrid(
+        dregg_sdk::raw::unsigned_action_named(cell, &f.topic, vec![effect]),
+        &federation_id,
+        nonce,
+    );
+    let mut turn: Turn = clerk.make_turn_with_actions(vec![action]);
+    turn.agent = cell;
+    turn.nonce = nonce;
+    turn.memo = Some(payload.clone());
+    turn.valid_until = Some(i64::MAX / 2);
+    turn.previous_receipt_hash = chain_head;
+    turn.fee = TurnExecutor::new(ComputronCosts::default()).estimate_cost(&turn);
+
+    let signed = clerk.sign_turn(&turn);
+    let bytes =
+        postcard::to_stdvec(&signed).map_err(|e| err(format!("serialize SignedTurn: {e}")))?;
+
+    let resp = http
+        .post(format!("{}/turns/submit", f.node_url))
+        .header("Content-Type", "application/octet-stream")
+        .header("Authorization", format!("Bearer {bearer}"))
+        .body(bytes)
+        .send()
+        .await
+        .map_err(|e| err(format!("POST /turns/submit: {e}")))?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(err(format!("/turns/submit returned {status}")));
+    }
+    let verdict: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| err(format!("parse submit response: {e}")))?;
+    if verdict.get("accepted").and_then(|a| a.as_bool()) != Some(true) {
+        return Err(err(format!(
+            "node refused the turn: {}",
+            verdict
+                .get("error")
+                .and_then(|e| e.as_str())
+                .unwrap_or("no reason given")
+        )));
+    }
+    let turn_hash = verdict
+        .get("turn_hash")
+        .and_then(|h| h.as_str())
+        .ok_or_else(|| err("accepted submit response missing turn_hash".to_string()))?
+        .to_string();
+    eprintln!("[client-sign] turn accepted: {turn_hash}; awaiting receipt...");
+
+    // Receipt resolution across the consensus-finality window (~2s typical).
+    // Fail-closed after 30s: exit 0 means RECEIPTED, never merely accepted.
+    for _ in 0..120 {
+        let receipts = get_json(&http, &format!("{}/api/receipts", f.node_url)).await?;
+        if let Some(r) = receipts.as_array().and_then(|arr| {
+            arr.iter()
+                .find(|r| r.get("turn_hash").and_then(|t| t.as_str()) == Some(&turn_hash))
+        }) {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "sent": true,
+                    "node": f.node_url,
+                    "profile": name,
+                    "agent_cell": cell_hex,
+                    "to": cell_hex,
+                    "topic": f.topic,
+                    "payload": payload,
+                    "turn_hash": turn_hash,
+                    "receipt_hash": r.get("receipt_hash"),
+                    "chain_index": r.get("chain_index"),
+                    "finality": r.get("finality"),
+                    "consensus_final": r.get("consensus_final"),
+                })
+            );
+            return Ok(());
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    Err(err(format!(
+        "turn {turn_hash} accepted but not receipted within 30s"
+    )))
+}
+
+#[tokio::main]
+async fn main() {
+    let mut argv: Vec<String> = std::env::args().skip(1).collect();
+    if argv.is_empty() {
+        eprintln!("{USAGE}");
+        std::process::exit(2);
+    }
+    let cmd = argv.remove(0);
+    let run = async {
+        let flags = parse_flags(argv)?;
+        match cmd.as_str() {
+            "join" => cmd_join(flags).await,
+            "send" => cmd_send(flags).await,
+            _ => Err(err(format!("unknown verb '{cmd}' (try --help)"))),
+        }
+    };
+    if let Err(e) = run.await {
+        eprintln!("[client-sign] error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/dregg-sdk-net/src/bin/dregg-client-sign.rs
+++ b/dregg-sdk-net/src/bin/dregg-client-sign.rs
@@ -427,7 +427,39 @@ async fn cmd_join(f: Flags) -> Result<()> {
     let (name, clerk) = resolve_clerk(f.profile.as_deref(), true)?;
     let cell_hex = hex::encode(clerk.cell_id("default").as_bytes());
     let pk_hex = hex::encode(clerk.public_key().0);
-    let funding = ensure_cell(&http, &f.node_url, &cell_hex, &pk_hex, f.fund, f.fund).await?;
+
+    // COORDINATION-EXEMPT JOIN: when the deployment opts into the coordination
+    // class (DREGG_COORDINATION_EXEMPT truthy — helm's `cell.coord_fee()==0`
+    // forwards the env), materializing the cell requires the amount=0 path
+    // (cell creation, free) and NEVER a faucet-funded grant. A faucet grant
+    // bricks the nonce on devnet after ~1 successful call and drains the cell
+    // on every failed retry — an exempt join that still routes through the
+    // faucet is the whole reason every seat has been DEGRADED|join_failed
+    // since the fleet reboot. The signer's own docs promised this class was
+    // free four months before any deployment turned it on.
+    //
+    // Non-exempt join is unchanged: `--fund N` (default 5000) calls the faucet.
+    // BOTH BOUNDS GO TO ZERO, not just the minimum. `ensure_cell` computes
+    // `funding_shortfall(initial, minimum_balance, target_balance)` and only
+    // returns early on `!materialized && shortfall == 0`. An ABSENT cell is
+    // `materialized`, so it always POSTs — with `amount: shortfall`, derived
+    // from TARGET. Leaving target at `f.fund` therefore still requested a
+    // FUNDED grant on the exact path an exempt join must never take: first
+    // join, cell does not exist yet. Measured live 2026-07-28 — the exempt
+    // banner printed and the very next line was
+    // `faucet refused funding: ... Ed25519 (classical) signature half failed`.
+    //
+    // With both at 0 the shortfall is 0, so the POST carries amount=0: the
+    // free materialization path, which returns success before any Transfer is
+    // built and needs no faucet signature at all.
+    let costs = fee_cost_model();
+    let (minimum_balance, target_balance) = if costs.coordination_exempt {
+        eprintln!("[client-sign] coordination-exempt join — materializing cell {cell_hex} (free, no faucet grant)");
+        (0u64, 0u64)
+    } else {
+        (f.fund, f.fund)
+    };
+    let funding = ensure_cell(&http, &f.node_url, &cell_hex, &pk_hex, minimum_balance, target_balance).await?;
     println!(
         "{}",
         serde_json::json!({

--- a/exec-lean/tests/coordination_exempt_differential.rs
+++ b/exec-lean/tests/coordination_exempt_differential.rs
@@ -1,0 +1,197 @@
+//! COORDINATION-TURN CLASS Lean/Rust differential ("leash, not ledger").
+//!
+//! The `ComputronCosts::coordination_exempt` class is ADMISSION-ONLY: it waives
+//! the CHARGE for EmitEvent-only turns (`Turn::is_coordination`) so a `fee = 0`
+//! coordination turn admits under REAL (non-zero) computron costs. `fee = 0` is
+//! the shape every prior Lean/Rust differential already locked (see
+//! `faucet_fee_well_divergence.rs`: "Every prior differential used `fee == 0`"),
+//! so exempting the class must introduce NO producer divergence — the state
+//! transition of a committed fee=0 EmitEvent turn is untouched; only the Rust
+//! admission gate changed. This test pins that: the SAME fee=0 chat turn, run
+//! through the exempt Rust executor (default costs — which would REJECT it
+//! without the exemption) and through the verified Lean producer, commits on
+//! both and agrees cell-by-cell + on `.root()`.
+//!
+//! Mirrors the `faucet_fee_well_divergence.rs` harness (open cells,
+//! `execute_via_lean`, `ledgers_agree`). Requires the linked Lean archive
+//! (`lean-shadow` + `lean_available()`); self-skips when absent (PANICS under
+//! `DREGG_TEST_REQUIRE_LEAN=1`).
+
+use dregg_cell::permissions::AuthRequired;
+use dregg_cell::{Cell, CellId, Ledger, Permissions};
+use dregg_exec_lean::lean_apply::execute_via_lean;
+use dregg_exec_lean::lean_shadow::ShadowHostCtx;
+use dregg_turn::{
+    Action, Authorization, CallForest, ComputronCosts, DelegationMode, Effect, Event, TurnExecutor,
+    turn::Turn,
+};
+use std::collections::HashMap;
+
+fn open_permissions() -> Permissions {
+    Permissions {
+        send: AuthRequired::None,
+        receive: AuthRequired::None,
+        set_state: AuthRequired::None,
+        set_permissions: AuthRequired::None,
+        set_verification_key: AuthRequired::None,
+        increment_nonce: AuthRequired::None,
+        delegate: AuthRequired::None,
+        access: AuthRequired::None,
+    }
+}
+
+fn make_open_cell(seed: u8, balance: i64) -> Cell {
+    let mut pk = [0u8; 32];
+    pk[0] = seed;
+    pk[31] = seed.wrapping_mul(37);
+    let mut cell = Cell::with_balance(pk, [0u8; 32], balance);
+    cell.permissions = open_permissions();
+    cell
+}
+
+/// An EmitEvent-only "chat" turn — the coordination shape, `fee = 0`.
+fn chat_turn(agent: CellId, payload: &[u8]) -> Turn {
+    let data = payload
+        .chunks(8)
+        .map(|chunk| {
+            let mut word = [0u8; 32];
+            word[24..24 + chunk.len()].copy_from_slice(chunk);
+            word
+        })
+        .collect();
+    let mut forest = CallForest::new();
+    forest.add_root(Action {
+        target: agent,
+        method: *blake3::hash(b"helm.chat").as_bytes(),
+        args: vec![],
+        authorization: Authorization::Unchecked,
+        preconditions: Default::default(),
+        effects: vec![Effect::EmitEvent {
+            cell: agent,
+            event: Event::new(*blake3::hash(b"helm.chat").as_bytes(), data),
+        }],
+        may_delegate: DelegationMode::None,
+        commitment_mode: Default::default(),
+        balance_change: None,
+        witness_blobs: vec![],
+    });
+    Turn {
+        agent,
+        nonce: 0,
+        call_forest: forest,
+        fee: 0,
+        memo: None,
+        valid_until: Some(1_000_000),
+        previous_receipt_hash: None,
+        depends_on: vec![],
+        conservation_proof: None,
+        sovereign_witnesses: HashMap::new(),
+        execution_proof: None,
+        execution_proof_cell: None,
+        execution_proof_new_commitment: None,
+        custom_program_proofs: None,
+        effect_binding_proofs: Vec::new(),
+        cross_effect_dependencies: Vec::new(),
+        effect_witness_index_map: Vec::new(),
+    }
+}
+
+fn skip_no_lean() -> bool {
+    !dregg_lean_ffi::demand_lean(
+        dregg_lean_ffi::lean_available(),
+        "Lean archive (lean_available)",
+    )
+}
+
+/// Compare two ledgers cell-by-cell (balance + nonce + leaf commitment) AND on `.root()`.
+fn ledgers_agree(
+    rust: &mut Ledger,
+    lean: &mut Ledger,
+    ids: &[(&str, CellId)],
+) -> Result<(), String> {
+    for (name, id) in ids {
+        let r = rust
+            .get(id)
+            .ok_or_else(|| format!("cell {name} missing from RUST ledger"))?;
+        let l = lean
+            .get(id)
+            .ok_or_else(|| format!("cell {name} missing from LEAN ledger"))?;
+        if r.state.balance() != l.state.balance() {
+            return Err(format!(
+                "balance divergence on {name}: rust={} lean={}",
+                r.state.balance(),
+                l.state.balance()
+            ));
+        }
+        if r.state.nonce() != l.state.nonce() {
+            return Err(format!(
+                "nonce divergence on {name}: rust={} lean={}",
+                r.state.nonce(),
+                l.state.nonce()
+            ));
+        }
+        let rc = dregg_cell::compute_canonical_state_commitment(r);
+        let lc = dregg_cell::compute_canonical_state_commitment(l);
+        if rc != lc {
+            return Err(format!(
+                "LEAF commitment divergence on {name}: rust={rc:?} lean={lc:?}"
+            ));
+        }
+    }
+    let rr = rust.root();
+    let lr = lean.root();
+    if rr != lr {
+        return Err(format!("ROOT divergence: rust={rr:?} lean={lr:?}"));
+    }
+    Ok(())
+}
+
+/// THE CLASS DIFFERENTIAL: a fee=0 EmitEvent-only chat turn from an UNFUNDED
+/// cell, admitted by the EXEMPT Rust executor under REAL costs, agrees with the
+/// verified Lean producer on full state + `.root()`.
+#[test]
+fn zero_fee_coordination_turn_agrees_across_producers() {
+    if skip_no_lean() {
+        return;
+    }
+    // UNFUNDED agent: balance 0 — the class's whole point (fleet comms cells
+    // need no faucet round-trip at all).
+    let agent = make_open_cell(3, 0);
+    let agent_id = agent.id();
+    let mut pre = Ledger::new();
+    pre.insert_cell(agent).unwrap();
+
+    let turn = chat_turn(agent_id, b"gm from the leash");
+
+    // RUST: REAL default costs + the exemption. Without `coordination_exempt`
+    // this exact turn REJECTS BudgetExceeded (locked in
+    // `turn/tests/coordination_fee_exempt.rs`); with it, it commits.
+    let mut costs = ComputronCosts::default_costs();
+    costs.coordination_exempt = true;
+    let executor = TurnExecutor::new(costs);
+    let mut rust_ledger = pre.clone();
+    let rust_result = executor.execute(&turn, &mut rust_ledger);
+    assert!(
+        rust_result.is_committed(),
+        "exempt Rust executor must commit the fee=0 chat turn: {rust_result:?}"
+    );
+
+    // LEAN: the verified producer on the SAME turn. fee=0 is the historically
+    // locked differential shape — the exemption changes Rust ADMISSION only,
+    // so the producers must agree exactly.
+    let host = ShadowHostCtx {
+        block_height: 0,
+        ..ShadowHostCtx::diag()
+    };
+    let (mut lean_ledger, lean_committed) = execute_via_lean(&turn, &pre, &host)
+        .unwrap_or_else(|e| panic!("Lean producer errored: {e}"));
+    assert!(
+        lean_committed,
+        "commit-bit divergence: Rust committed, Lean did not"
+    );
+
+    let ids = [("agent", agent_id)];
+    if let Err(e) = ledgers_agree(&mut rust_ledger, &mut lean_ledger, &ids) {
+        panic!("coordination-class differential diverged: {e}");
+    }
+}

--- a/exec-lean/tests/faucet_fee_well_divergence.rs
+++ b/exec-lean/tests/faucet_fee_well_divergence.rs
@@ -30,10 +30,10 @@ use std::collections::HashMap;
 
 use dregg_cell::permissions::AuthRequired;
 use dregg_cell::{Cell, CellId, Ledger, Permissions};
-use dregg_exec_lean::lean_apply::execute_via_lean;
+use dregg_exec_lean::lean_apply::{ProducerOutcome, execute_via_lean, produce_via_lean};
 use dregg_exec_lean::lean_shadow::ShadowHostCtx;
 use dregg_turn::{
-    Action, Authorization, CallForest, ComputronCosts, DelegationMode, Effect, TurnExecutor,
+    Action, Authorization, CallForest, ComputronCosts, DelegationMode, Effect, Event, TurnExecutor,
     turn::Turn,
 };
 
@@ -95,10 +95,76 @@ fn transfer_turn(agent: CellId, from: CellId, to: CellId, amount: u64, fee: u64)
     }
 }
 
+fn chat_turn(agent: CellId, payload: &[u8], fee: u64) -> Turn {
+    let data = payload
+        .chunks(8)
+        .map(|chunk| {
+            let mut word = [0u8; 32];
+            word[24..24 + chunk.len()].copy_from_slice(chunk);
+            word
+        })
+        .collect();
+    let mut forest = CallForest::new();
+    forest.add_root(Action {
+        target: agent,
+        method: *blake3::hash(b"helm.chat").as_bytes(),
+        args: vec![],
+        authorization: Authorization::Unchecked,
+        preconditions: Default::default(),
+        effects: vec![Effect::EmitEvent {
+            cell: agent,
+            event: Event::new(*blake3::hash(b"helm.chat").as_bytes(), data),
+        }],
+        may_delegate: DelegationMode::None,
+        commitment_mode: Default::default(),
+        balance_change: None,
+        witness_blobs: vec![],
+    });
+    Turn {
+        agent,
+        nonce: 0,
+        call_forest: forest,
+        fee,
+        memo: Some(String::from_utf8(payload.to_vec()).expect("test payload is UTF-8")),
+        valid_until: Some(1_000_000),
+        previous_receipt_hash: None,
+        depends_on: vec![],
+        conservation_proof: None,
+        sovereign_witnesses: HashMap::new(),
+        execution_proof: None,
+        execution_proof_cell: None,
+        execution_proof_new_commitment: None,
+        custom_program_proofs: None,
+        effect_binding_proofs: Vec::new(),
+        cross_effect_dependencies: Vec::new(),
+        effect_witness_index_map: Vec::new(),
+    }
+}
+
+fn assert_producer_agreed(outcome: ProducerOutcome, label: &str) {
+    match outcome {
+        ProducerOutcome::LeanAuthoritative {
+            committed,
+            rust_agreed,
+            lean_root,
+            rust_root,
+            rust_committed,
+        } => {
+            assert!(committed, "Lean must commit the {label}");
+            assert!(rust_committed, "Rust must commit the {label}");
+            assert!(
+                rust_agreed,
+                "Lean/Rust authority divergence on {label}: lean_root={lean_root:?} rust_root={rust_root:?}"
+            );
+            assert_eq!(lean_root, rust_root, "root agreement on {label}");
+        }
+        ProducerOutcome::Fallback { reason } => {
+            panic!("{label} escaped the verified producer through fallback: {reason}")
+        }
+    }
+}
+
 fn skip_no_lean() -> bool {
-    // Routed through the DREGG_TEST_REQUIRE_LEAN hard mode (dregg-lean-ffi::demand_lean):
-    // unarmed, an archive-less build prints the honest SKIP and returns; ARMED, it PANICS —
-    // so this suite can never report `ok` having asserted nothing on the hard-mode lane.
     !dregg_lean_ffi::demand_lean(
         dregg_lean_ffi::lean_available(),
         "Lean archive (lean_available)",
@@ -357,4 +423,72 @@ fn committed_height_family_agrees() {
                 .unwrap_or_else(|e| panic!("height={height} fee={fee} must agree: {e}"));
         }
     }
+}
+
+/// Regression for the shared-chat starvation incident. The signer already existed with only 90
+/// computrons, so treating `found:true` as "funded" left every later chat turn permanently rejected.
+/// Prove the owner faucet can commit a top-up INTO that existing cell, the authoritative balance
+/// rises to 5,000, and the exact next metered chat-sized `EmitEvent` then commits. Both commits stay
+/// on the verified producer and require full Lean/Rust verdict + root agreement.
+#[test]
+fn low_balance_recipient_top_up_commits_then_chat_send_commits() {
+    if skip_no_lean() {
+        return;
+    }
+
+    let faucet = make_open_cell(1, 1_000_000);
+    let recipient = make_open_cell(2, 90);
+    let fee_well = make_open_cell(9, 0);
+    let faucet_id = faucet.id();
+    let recipient_id = recipient.id();
+    let fee_well_id = fee_well.id();
+    let mut ledger = Ledger::new();
+    ledger.insert_cell(faucet).unwrap();
+    ledger.insert_cell(recipient).unwrap();
+    ledger.insert_cell(fee_well).unwrap();
+
+    let payload = b"This next chat-sized send must commit after the faucet top-up has actually raised the existing cell balance.";
+    let costs = ComputronCosts::default();
+    let mut chat = chat_turn(recipient_id, payload, 0);
+    chat.fee = TurnExecutor::new(costs.clone()).estimate_cost(&chat);
+    assert!(
+        chat.fee > 90 && chat.fee < 5_000,
+        "test must be load-bearing: chat fee {} must exceed the depleted balance but fit after top-up",
+        chat.fee
+    );
+    let mut depleted = ledger.clone();
+    let rejected = TurnExecutor::new(costs.clone()).execute(&chat, &mut depleted);
+    assert!(
+        !rejected.is_committed(),
+        "depleted precondition must genuinely reject the chat turn: {rejected:?}"
+    );
+
+    let top_up = transfer_turn(faucet_id, faucet_id, recipient_id, 4_910, 0);
+    let top_up_executor = TurnExecutor::new(ComputronCosts::zero());
+    let (top_up_result, top_up_outcome) = produce_via_lean(&top_up_executor, &top_up, &mut ledger);
+    assert!(top_up_result.is_committed(), "faucet top-up must commit");
+    assert_producer_agreed(top_up_outcome, "existing-recipient faucet top-up");
+    assert_eq!(
+        ledger.get(&recipient_id).unwrap().state.balance(),
+        5_000,
+        "committed top-up must raise the existing recipient balance"
+    );
+
+    let mut chat_executor = TurnExecutor::new(costs);
+    chat_executor.set_fee_well_cell(fee_well_id);
+    let (chat_result, chat_outcome) = produce_via_lean(&chat_executor, &chat, &mut ledger);
+    assert!(
+        chat_result.is_committed(),
+        "post-top-up chat send must commit"
+    );
+    assert_producer_agreed(chat_outcome, "post-top-up chat send");
+    assert!(
+        ledger.get(&recipient_id).unwrap().state.balance() < 5_000,
+        "chat turn must really execute and spend its fee"
+    );
+    assert_eq!(
+        ledger.get(&fee_well_id).unwrap().state.balance(),
+        chat.fee as i64,
+        "the committed chat fee must reach the configured fee well"
+    );
 }

--- a/exec-lean/tests/faucet_fee_well_divergence.rs
+++ b/exec-lean/tests/faucet_fee_well_divergence.rs
@@ -30,11 +30,11 @@ use std::collections::HashMap;
 
 use dregg_cell::permissions::AuthRequired;
 use dregg_cell::{Cell, CellId, Ledger, Permissions};
-use dregg_exec_lean::lean_apply::{ProducerOutcome, execute_via_lean, produce_via_lean};
+use dregg_exec_lean::lean_apply::{execute_via_lean, produce_via_lean, ProducerOutcome};
 use dregg_exec_lean::lean_shadow::ShadowHostCtx;
 use dregg_turn::{
-    Action, Authorization, CallForest, ComputronCosts, DelegationMode, Effect, Event, TurnExecutor,
-    turn::Turn,
+    turn::Turn, Action, Authorization, CallForest, ComputronCosts, DelegationMode, Effect, Event,
+    TurnExecutor,
 };
 
 fn open_permissions() -> Permissions {
@@ -104,6 +104,10 @@ fn chat_turn(agent: CellId, payload: &[u8], fee: u64) -> Turn {
             word
         })
         .collect();
+    // The current verified wire carries event topics losslessly only in its low-64 lane.
+    // Keep the chat-sized payload exact while choosing a topic that stays on the Lean producer.
+    let mut topic = [0u8; 32];
+    topic[24..].copy_from_slice(&11u64.to_be_bytes());
     let mut forest = CallForest::new();
     forest.add_root(Action {
         target: agent,
@@ -113,7 +117,7 @@ fn chat_turn(agent: CellId, payload: &[u8], fee: u64) -> Turn {
         preconditions: Default::default(),
         effects: vec![Effect::EmitEvent {
             cell: agent,
-            event: Event::new(*blake3::hash(b"helm.chat").as_bytes(), data),
+            event: Event::new(topic, data),
         }],
         may_delegate: DelegationMode::None,
         commitment_mode: Default::default(),
@@ -149,12 +153,17 @@ fn assert_producer_agreed(outcome: ProducerOutcome, label: &str) {
             lean_root,
             rust_root,
             rust_committed,
+            divergence,
         } => {
             assert!(committed, "Lean must commit the {label}");
             assert!(rust_committed, "Rust must commit the {label}");
             assert!(
                 rust_agreed,
-                "Lean/Rust authority divergence on {label}: lean_root={lean_root:?} rust_root={rust_root:?}"
+                "Lean/Rust authority divergence on {label}: lean_root={lean_root:?} rust_root={rust_root:?} divergence={divergence:?}"
+            );
+            assert!(
+                divergence.is_none(),
+                "divergence leg named on {label} despite agreement: {divergence:?}"
             );
             assert_eq!(lean_root, rust_root, "root agreement on {label}");
         }
@@ -428,8 +437,8 @@ fn committed_height_family_agrees() {
 /// Regression for the shared-chat starvation incident. The signer already existed with only 90
 /// computrons, so treating `found:true` as "funded" left every later chat turn permanently rejected.
 /// Prove the owner faucet can commit a top-up INTO that existing cell, the authoritative balance
-/// rises to 5,000, and the exact next metered chat-sized `EmitEvent` then commits. Both commits stay
-/// on the verified producer and require full Lean/Rust verdict + root agreement.
+/// rises to 5,000, and the same metered chat-sized `EmitEvent` then commits. Both commits stay on
+/// the verified producer and require full Lean/Rust verdict + root agreement.
 #[test]
 fn low_balance_recipient_top_up_commits_then_chat_send_commits() {
     if skip_no_lean() {

--- a/node/src/api.rs
+++ b/node/src/api.rs
@@ -7674,6 +7674,17 @@ pub(crate) fn faucet_public_key() -> [u8; 32] {
     faucet_signing_key().verifying_key().to_bytes()
 }
 
+/// The faucet cell's deterministic `CellId` under the default asset.
+///
+/// THE FEE LOOP (revolving fund): this is the single cell the genesis-less
+/// devnet backfill (`lib.rs`) points the fee well at, so every per-turn fee
+/// move recirculates into the pool the faucet pays out of — closing the loop
+/// that otherwise drained the faucet monotonically. Derived identically to the
+/// genesis faucet cell, so both boot modes name the SAME cell.
+pub(crate) fn faucet_cell_id() -> dregg_cell::CellId {
+    dregg_cell::CellId::derive_raw(&faucet_public_key(), &faucet_token_id())
+}
+
 #[derive(Deserialize)]
 pub struct FaucetRequest {
     /// Hex-encoded 32-byte recipient cell ID.

--- a/node/src/executor_setup.rs
+++ b/node/src/executor_setup.rs
@@ -390,6 +390,13 @@ pub fn configure_turn_executor(
         executor.register_issuer_well(*token_id, *well);
     }
 
+    // COORDINATION-TURN CLASS ("leash, not ledger"): genesis-declared opt-in
+    // (`genesis.json` `coordination_fee_exempt` → NodeState). EmitEvent-only
+    // turns with no `balance_change` may carry `fee = 0` — the executor waives
+    // the CHARGE while the receipt's `computrons_used` stays honest. Default
+    // off: zero behavior change unless a deployment opts in at genesis.
+    executor.costs.coordination_exempt = s.coordination_fee_exempt;
+
     let base = attested_block_height(s);
     let height = match height_mode {
         BlockHeightMode::Current => base,

--- a/node/src/genesis.rs
+++ b/node/src/genesis.rs
@@ -512,6 +512,10 @@ pub fn run_genesis_with_options(
         threshold,
         initial_cells,
         issuer_well: issuer_well_id,
+        // Upstream's standalone fee-well cell stands in FRESH genesis; the
+        // fork's revolving fund (fee well == faucet) applies on the
+        // genesis-less devnet via the lib.rs backfill, which is the mode the
+        // cave node actually runs.
         fee_well: fee_well_id,
         genesis_moves,
         starbridge_cells,

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1543,6 +1543,27 @@ async fn run_node(
                 "starbridge devnet backfill seeding complete (default cell set)"
             );
         }
+        // THE FEE LOOP (revolving fund): a genesis-less devnet cave node never
+        // hits the `genesis.json`-exists branch above (lib.rs:1229-1236), so
+        // `s.fee_well` is still None here — which means every per-turn fee
+        // remainder BURNS (execute.rs distribute_fee_shares fallback), and the
+        // faucet, a pure payer-out, drains monotonically (~800-turn runway →
+        // "insufficient balance ... need 1254" → signing DEGRADED). Point the
+        // fee well at the FAUCET cell so each committed turn's fee move
+        // recirculates into the exact pool the faucet pays out of: the
+        // {agents + faucet} value set is now closed (no external sink), payouts
+        // out are offset by fees in, and the coordination-turn class stays
+        // fee-bearing (the debit + budget gate + 1/min faucet rate-limit remain
+        // the oversight leash — no fee is zeroed). Idempotent: only sets the
+        // well when unset, so a genesis-configured well is never overwritten.
+        if s.fee_well.is_none() {
+            let faucet_cell_id = crate::api::faucet_cell_id();
+            info!(
+                fee_well = %faucet_cell_id,
+                "fee loop: genesis-less devnet fee well pointed at the faucet cell (recirculate, not burn)"
+            );
+            s.fee_well = Some(faucet_cell_id);
+        }
     }
 
     // Demo execution-lease seed — the local-cloud loop's mint. An external

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1455,6 +1455,20 @@ async fn run_node(
                                 ),
                             }
                         }
+                        // COORDINATION-TURN CLASS ("leash, not ledger"):
+                        // genesis-declared opt-in. EmitEvent-only turns (no
+                        // balance_change) may carry fee = 0 — the charge is
+                        // waived at admission, the receipt's computrons_used
+                        // stays honest. Genesis-declared so every committee
+                        // node agrees; default off = exact legacy behavior.
+                        if let Some(exempt) = genesis["coordination_fee_exempt"].as_bool() {
+                            s.coordination_fee_exempt = exempt;
+                            if exempt {
+                                info!(
+                                    "genesis coordination_fee_exempt: EmitEvent-only turns are fee-exempt"
+                                );
+                            }
+                        }
                         if let Some(issuer_well_hex) = genesis["issuer_well"].as_str() {
                             match hex_decode_32(issuer_well_hex) {
                                 // The well backs the asset it is MINTED IN — read

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1578,6 +1578,24 @@ async fn run_node(
             );
             s.fee_well = Some(faucet_cell_id);
         }
+        // COORDINATION-TURN CLASS ("leash, not ledger") — half (a) of the
+        // signed-turn transport fix. Same genesis-less devnet cave node never
+        // hits the `genesis.json`-exists branch above (lib.rs:1229-1247), so
+        // `s.coordination_fee_exempt` is still its `false` default here — which
+        // means the compiled-in exempt class is OFF on our devnet, and every
+        // coordination turn (chat/gate/status/meld — EmitEvent-only, no
+        // balance_change) still pays the per-turn fee, drains its cell, and hits
+        // the faucet's 1/min grant rate-limit → falls back to `[unsigned]`.
+        // Mirror the fee_well backfill above: turn the class ON at this dogfood
+        // boot so `configure_turn_executor` wires `costs.coordination_exempt =
+        // true` onto every executor. Metering stays honest (receipts keep the
+        // true `computrons_used`); only the ADMISSION CHARGE is waived, and only
+        // for EmitEvent-only turns — economic turns (Transfer/Burn/…) charge
+        // exactly as before. Gated by the same `--enable-faucet` devnet path.
+        info!(
+            "coordination class: genesis-less devnet fee-exempts EmitEvent-only turns (leash, not ledger)"
+        );
+        s.coordination_fee_exempt = true;
     }
 
     // Demo execution-lease seed — the local-cloud loop's mint. An external

--- a/node/src/state.rs
+++ b/node/src/state.rs
@@ -496,6 +496,17 @@ pub struct NodeStateInner {
     /// shares MOVE here instead of burning — committed turns conserve
     /// exactly.
     pub fee_well: Option<CellId>,
+    /// COORDINATION-TURN fee exemption from genesis (`genesis.json`
+    /// `coordination_fee_exempt`, default `false`). Genesis-declared so every
+    /// committee node agrees — admission is consensus-relevant. Wired onto
+    /// every executor via
+    /// [`crate::executor_setup::configure_turn_executor`] as
+    /// `costs.coordination_exempt`: EmitEvent-only turns with no
+    /// `balance_change` may then carry `fee = 0` ("leash, not ledger" — the
+    /// computron is an oversight budget, and coordination turns ARE the
+    /// oversight traffic). Economic turns charge exactly as before; receipts
+    /// keep the true `computrons_used`.
+    pub coordination_fee_exempt: bool,
     /// THE EPOCH §5 ("burn as issuer-move"): (token_id → issuer well cell)
     /// registrations from genesis (`genesis.json` `issuer_well`, registered
     /// for the default asset). Wired onto every executor so `Burn` executes
@@ -1348,6 +1359,7 @@ impl NodeState {
                     dregg_lean_ffi::lean_available(),
                 ),
                 fee_well: None,
+                coordination_fee_exempt: false,
                 issuer_wells: Vec::new(),
                 mcp_cap_enforce: mcp_cap_enforce_env_enabled(),
                 pir_index_cache: None,
@@ -1545,6 +1557,7 @@ impl NodeState {
                     dregg_lean_ffi::lean_available(),
                 ),
                 fee_well: None,
+                coordination_fee_exempt: false,
                 issuer_wells: Vec::new(),
                 mcp_cap_enforce: mcp_cap_enforce_env_enabled(),
                 pir_index_cache: None,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -326,7 +326,7 @@ pub use cipherclerk::{
     DisclosureSpec, FactDisclosure, FactIndex, HeldToken, LocalDelegation, OwnedStealthNote,
     VerificationMode,
 };
-pub use dregg_token::{Attenuation, AuthRequest, AuthToken};
+pub use dregg_token::{Attenuation, AuthRequest, AuthToken, BudgetSpec};
 
 // The factory/polis plan builders (authorized by construction: they emit
 // effect lists that ride `runtime.turn().effects(..)` / the execute paths).

--- a/sdk/tests/public_api.rs
+++ b/sdk/tests/public_api.rs
@@ -1,0 +1,5 @@
+//! Compile-time canaries for SDK-root compatibility exports used by downstream crates.
+
+use dregg_sdk::{Attenuation, AuthRequest, BudgetSpec, CellId, SignedTurn};
+
+const _: Option<(Attenuation, AuthRequest, BudgetSpec, CellId, SignedTurn)> = None;

--- a/turn/src/executor/costs.rs
+++ b/turn/src/executor/costs.rs
@@ -23,6 +23,19 @@ pub struct ComputronCosts {
     pub signature_verify: u64,
     /// Cost per byte of data processed.
     pub per_byte: u64,
+    /// Waive the CHARGE for COORDINATION turns
+    /// ([`Turn::is_coordination`](crate::turn::Turn::is_coordination):
+    /// EmitEvent-only, no `balance_change`) — "leash, not ledger": the
+    /// computron is an oversight budget, and coordination turns are the
+    /// oversight traffic itself. Opt-in, default `false` = exact legacy
+    /// behavior; `#[serde(default)]` keeps persisted/wire cost configs
+    /// compatible. When enabled, a `fee = 0` coordination turn admits and
+    /// commits; metering stays honest (receipts still report the true
+    /// `computrons_used` — only the admission charge is waived) and economic
+    /// turns (Transfer/Burn/NoteSpend/CreateCell/SetField/…) charge exactly
+    /// as before.
+    #[serde(default)]
+    pub coordination_exempt: bool,
 }
 
 impl ComputronCosts {
@@ -36,6 +49,7 @@ impl ComputronCosts {
             proof_verify: 1000,
             signature_verify: 200,
             per_byte: 1,
+            coordination_exempt: false,
         }
     }
 
@@ -49,6 +63,7 @@ impl ComputronCosts {
             proof_verify: 0,
             signature_verify: 0,
             per_byte: 0,
+            coordination_exempt: false,
         }
     }
 }

--- a/turn/src/executor/execute.rs
+++ b/turn/src/executor/execute.rs
@@ -16,8 +16,18 @@ use super::*;
 /// unconfigured or missing) moves to the FEE WELL when one is configured, so
 /// the turn's total value delta is exactly zero (`reachable_total_zero`'s
 /// hypotheses hold on the deployed chain, where genesis always configures
-/// the well). With no fee well configured the undelivered remainder is
-/// burned — the legacy pre-epoch semantics, kept only for well-less tests.
+/// the well).
+///
+/// THE FEE LOOP (revolving fund): on devnet the fee well POINTS AT the faucet
+/// cell (genesis-less backfill at `node/src/lib.rs`, and `fee_well: faucet_id`
+/// in `node/src/genesis.rs`). So the `fee - delivered` credit here recirculates
+/// straight back into the pool the faucet pays out of — closing the loop that
+/// otherwise drained the faucet monotonically. NO fee is zeroed: the debit +
+/// budget gate + faucet 1/min rate-limit remain the oversight leash.
+///
+/// With no fee well configured the undelivered remainder is burned — the legacy
+/// pre-epoch semantics, kept only for well-less tests (every deployed boot mode
+/// now configures the well, so this fallback is test-only).
 fn distribute_fee_shares(
     ledger: &mut Ledger,
     proposer: Option<&CellId>,

--- a/turn/src/executor/execute.rs
+++ b/turn/src/executor/execute.rs
@@ -1115,6 +1115,20 @@ impl TurnExecutor {
         let mut journal = LedgerJournal::with_capacity(16);
         let mut computrons_used: u64 = 0;
         let mut all_effects_hashes: Vec<[u8; 32]> = Vec::new();
+
+        // COORDINATION EXEMPTION ("leash, not ledger") — opt-in via
+        // `ComputronCosts::coordination_exempt`. An EmitEvent-only turn with no
+        // `balance_change` anywhere in its forest (`Turn::is_coordination`) is
+        // oversight traffic, so its CHARGE is waived: the tree walk meters with
+        // an uncapped budget (so `computrons_used` stays the TRUE cost in the
+        // receipt) and the admission comparison below charges 0. Economic turns
+        // are untouched — any non-EmitEvent effect disqualifies the whole turn.
+        let coordination_exempt = self.costs.coordination_exempt && turn.is_coordination();
+        let metering_budget = if coordination_exempt {
+            u64::MAX
+        } else {
+            turn.fee
+        };
         let mut excess: i64 = 0; // Mina-style excess: must be zero at turn end.
         // Per-asset conservation accumulator: `(target-cell 32-byte asset id,
         // delta)` for every `balance_change`, grouped by the target's committed
@@ -1147,7 +1161,7 @@ impl TurnExecutor {
                 // implemented) in execute_tree.
                 DelegationMode::ParentsOwn,
                 &mut computrons_used,
-                turn.fee,
+                metering_budget,
                 &mut all_effects_hashes,
                 vec![root_idx],
                 &mut journal,
@@ -1198,8 +1212,16 @@ impl TurnExecutor {
         }
         let _pt_post = super::turn_profile::Instant::now();
 
-        // Check total cost against fee.
-        if computrons_used > turn.fee {
+        // Check total cost against fee. A coordination-exempt turn CHARGES 0
+        // (the class waiver) while `computrons_used` keeps the true metered
+        // cost for the receipt — the leash stays observable, only the toll is
+        // waived.
+        let charged = if coordination_exempt {
+            0
+        } else {
+            computrons_used
+        };
+        if charged > turn.fee {
             journal.rollback(
                 ledger,
                 &self.bridged_nullifiers,
@@ -1683,7 +1705,16 @@ impl TurnExecutor {
     }
 
     /// Estimate the computron cost of a turn without applying it.
+    ///
+    /// A COORDINATION turn (`Turn::is_coordination`) estimates 0 when the
+    /// executor opts into `ComputronCosts::coordination_exempt` — the
+    /// admission-side mirror of the execution-path charge waiver, so
+    /// `validate_without_apply` and fee-sizing clients agree that the class
+    /// rides free ("leash, not ledger").
     pub fn estimate_cost(&self, turn: &Turn) -> u64 {
+        if self.costs.coordination_exempt && turn.is_coordination() {
+            return 0;
+        }
         let mut total: u64 = 0;
         for root in &turn.call_forest.roots {
             total = total.saturating_add(self.estimate_tree_cost(root));

--- a/turn/src/turn.rs
+++ b/turn/src/turn.rs
@@ -689,6 +689,35 @@ impl Turn {
         self.call_forest.action_count()
     }
 
+    /// Is this a COORDINATION turn — observable, append-only, non-state-mutating?
+    ///
+    /// True iff the call forest is non-empty AND every action in it (recursing
+    /// through children) declares no `balance_change` and produces ONLY
+    /// [`Effect::EmitEvent`](crate::action::Effect::EmitEvent) effects. Such
+    /// turns are oversight traffic (status posts, gate verdicts, chat): they
+    /// move no value and mutate no cell state beyond the append-only event log.
+    ///
+    /// Consumed by the opt-in
+    /// [`ComputronCosts::coordination_exempt`](crate::executor::ComputronCosts)
+    /// class ("leash, not ledger" — the computron is an oversight budget, not an
+    /// economic cost): when a deployment opts in, the executor waives the CHARGE
+    /// for this class (a `fee = 0` coordination turn admits) while metering
+    /// stays honest — receipts still report the true `computrons_used`. Any
+    /// non-`EmitEvent` effect or any `balance_change` disqualifies the whole
+    /// turn, so the class cannot leak to value moves.
+    pub fn is_coordination(&self) -> bool {
+        fn tree_is_coordination(tree: &crate::forest::CallTree) -> bool {
+            tree.action.balance_change.is_none()
+                && tree
+                    .action
+                    .effects
+                    .iter()
+                    .all(|e| matches!(e, crate::action::Effect::EmitEvent { .. }))
+                && tree.children.iter().all(tree_is_coordination)
+        }
+        !self.call_forest.is_empty() && self.call_forest.roots.iter().all(tree_is_coordination)
+    }
+
     /// Every effect this turn will apply, paired with the target of the action
     /// that carries it, **in the executor's apply order**.
     ///

--- a/turn/tests/coordination_fee_exempt.rs
+++ b/turn/tests/coordination_fee_exempt.rs
@@ -1,0 +1,292 @@
+//! COORDINATION-TURN CLASS regression lock ("leash, not ledger").
+//!
+//! `ComputronCosts::coordination_exempt` (opt-in, default off) waives the
+//! CHARGE for turns that are pure oversight traffic — EmitEvent-only, no
+//! `balance_change` anywhere in the forest (`Turn::is_coordination`). The
+//! computron stays a LEASH (metering is honest: receipts report the true
+//! `computrons_used`) but stops being a LEDGER for the class (a `fee = 0`
+//! coordination turn admits and commits, even from an UNFUNDED cell).
+//!
+//! Locked both ways:
+//! - exempt=true : fee=0 EmitEvent-only turn COMMITS (even at balance 0);
+//! - exempt=false: the same turn still REJECTS `BudgetExceeded` (legacy
+//!   behavior is bit-identical when the flag is off — the upstream default);
+//! - no leak     : a `Transfer` (economic) turn at fee=0 REJECTS even under
+//!   exempt=true — the class cannot leak to value moves;
+//! - honest leash: the exempted turn's receipt reports NONZERO
+//!   `computrons_used`;
+//! - admission mirror: `estimate_cost` / `validate_without_apply` agree with
+//!   the execution path on both sides of the flag.
+
+use dregg_cell::{AuthRequired, Cell, CellId, Ledger, Permissions};
+use dregg_turn::{
+    Action, Authorization, CallForest, ComputronCosts, DelegationMode, Effect, Event, TurnError,
+    TurnExecutor,
+    turn::{Turn, TurnResult},
+};
+
+fn open_permissions() -> Permissions {
+    Permissions {
+        send: AuthRequired::None,
+        receive: AuthRequired::None,
+        set_state: AuthRequired::None,
+        set_permissions: AuthRequired::None,
+        set_verification_key: AuthRequired::None,
+        increment_nonce: AuthRequired::None,
+        delegate: AuthRequired::None,
+        access: AuthRequired::None,
+    }
+}
+
+fn make_open_cell(seed: u8, balance: i64) -> Cell {
+    let mut pk = [0u8; 32];
+    pk[0] = seed;
+    pk[31] = seed.wrapping_mul(37);
+    let mut cell = Cell::with_balance(pk, [0u8; 32], balance);
+    cell.permissions = open_permissions();
+    cell
+}
+
+fn turn_with_effects(agent: CellId, effects: Vec<Effect>, fee: u64) -> Turn {
+    let mut forest = CallForest::new();
+    forest.add_root(Action {
+        target: agent,
+        method: *blake3::hash(b"helm.chat").as_bytes(),
+        args: vec![],
+        authorization: Authorization::Unchecked,
+        preconditions: Default::default(),
+        effects,
+        may_delegate: DelegationMode::None,
+        commitment_mode: Default::default(),
+        balance_change: None,
+        witness_blobs: vec![],
+    });
+    Turn {
+        agent,
+        nonce: 0,
+        call_forest: forest,
+        fee,
+        memo: None,
+        valid_until: None,
+        previous_receipt_hash: None,
+        depends_on: vec![],
+        conservation_proof: None,
+        sovereign_witnesses: std::collections::HashMap::new(),
+        execution_proof: None,
+        execution_proof_cell: None,
+        execution_proof_new_commitment: None,
+        custom_program_proofs: None,
+        effect_binding_proofs: Vec::new(),
+        cross_effect_dependencies: Vec::new(),
+        effect_witness_index_map: Vec::new(),
+    }
+}
+
+/// An EmitEvent-only "chat" turn — the coordination shape.
+fn chat_turn(agent: CellId, fee: u64) -> Turn {
+    turn_with_effects(
+        agent,
+        vec![Effect::EmitEvent {
+            cell: agent,
+            event: Event::new(*blake3::hash(b"helm.chat").as_bytes(), vec![[7u8; 32]]),
+        }],
+        fee,
+    )
+}
+
+/// A `Transfer` (economic) turn — must NEVER ride the exemption.
+fn transfer_turn(agent: CellId, to: CellId, amount: u64, fee: u64) -> Turn {
+    turn_with_effects(
+        agent,
+        vec![Effect::Transfer {
+            from: agent,
+            to,
+            amount,
+        }],
+        fee,
+    )
+}
+
+fn exempt_executor() -> TurnExecutor {
+    let mut costs = ComputronCosts::default_costs();
+    costs.coordination_exempt = true;
+    TurnExecutor::new(costs)
+}
+
+#[test]
+fn is_coordination_classifies() {
+    let agent = make_open_cell(1, 0).id();
+    let to = make_open_cell(2, 0).id();
+    assert!(chat_turn(agent, 0).is_coordination());
+    assert!(!transfer_turn(agent, to, 1, 0).is_coordination());
+    // Mixed forest (EmitEvent + Transfer) is NOT coordination.
+    let mixed = turn_with_effects(
+        agent,
+        vec![
+            Effect::EmitEvent {
+                cell: agent,
+                event: Event::new([1u8; 32], vec![]),
+            },
+            Effect::Transfer {
+                from: agent,
+                to,
+                amount: 1,
+            },
+        ],
+        0,
+    );
+    assert!(!mixed.is_coordination());
+    // A declared balance_change disqualifies even an EmitEvent-only action.
+    let mut declared = chat_turn(agent, 0);
+    declared.call_forest.roots[0].action.balance_change = Some(0);
+    assert!(!declared.is_coordination());
+    // A zero-effect action is still non-mutating: coordination.
+    let no_effects = turn_with_effects(agent, vec![], 0);
+    assert!(no_effects.is_coordination());
+    // An EMPTY forest is NOT coordination (nothing to classify; the executor
+    // rejects it as EmptyForest anyway).
+    let mut empty = chat_turn(agent, 0);
+    empty.call_forest = CallForest::new();
+    assert!(!empty.is_coordination());
+}
+
+#[test]
+fn zero_fee_chat_commits_when_exempt_even_unfunded() {
+    let agent = make_open_cell(1, 0); // UNFUNDED — the class's whole point
+    let agent_id = agent.id();
+    let mut ledger = Ledger::new();
+    ledger.insert_cell(agent).unwrap();
+
+    let executor = exempt_executor();
+    let turn = chat_turn(agent_id, 0);
+    let result = executor.execute(&turn, &mut ledger);
+    assert!(
+        result.is_committed(),
+        "exempt fee=0 chat turn must commit: {result:?}"
+    );
+}
+
+#[test]
+fn zero_fee_chat_still_rejects_when_not_exempt() {
+    // Regression lock the OTHER way: with the flag off (the upstream
+    // default), behavior is exactly legacy — fee=0 cannot cover the metered
+    // cost and the turn rejects BudgetExceeded.
+    let agent = make_open_cell(1, 1_000_000);
+    let agent_id = agent.id();
+    let mut ledger = Ledger::new();
+    ledger.insert_cell(agent).unwrap();
+
+    let executor = TurnExecutor::new(ComputronCosts::default_costs());
+    let turn = chat_turn(agent_id, 0);
+    match executor.execute(&turn, &mut ledger) {
+        TurnResult::Rejected {
+            reason: TurnError::BudgetExceeded { .. },
+            ..
+        } => {}
+        other => panic!("non-exempt fee=0 chat turn must reject BudgetExceeded, got {other:?}"),
+    }
+}
+
+#[test]
+fn zero_fee_transfer_rejects_even_when_exempt() {
+    // NO LEAK: an economic turn cannot ride the coordination class.
+    let agent = make_open_cell(1, 1_000_000);
+    let recipient = make_open_cell(2, 0);
+    let agent_id = agent.id();
+    let recipient_id = recipient.id();
+    let mut ledger = Ledger::new();
+    ledger.insert_cell(agent).unwrap();
+    ledger.insert_cell(recipient).unwrap();
+
+    let executor = exempt_executor();
+    let turn = transfer_turn(agent_id, recipient_id, 100, 0);
+    match executor.execute(&turn, &mut ledger) {
+        TurnResult::Rejected {
+            reason: TurnError::BudgetExceeded { .. },
+            ..
+        } => {}
+        other => panic!("fee=0 Transfer must reject even under exempt, got {other:?}"),
+    }
+}
+
+#[test]
+fn exempt_receipt_keeps_honest_computrons_used() {
+    // The leash stays observable: only the CHARGE is waived, the metering is
+    // real — the receipt must report the true nonzero cost.
+    let agent = make_open_cell(1, 0);
+    let agent_id = agent.id();
+    let mut ledger = Ledger::new();
+    ledger.insert_cell(agent).unwrap();
+
+    let executor = exempt_executor();
+    let turn = chat_turn(agent_id, 0);
+    match executor.execute(&turn, &mut ledger) {
+        TurnResult::Committed {
+            receipt,
+            computrons_used,
+            ..
+        } => {
+            assert!(
+                computrons_used > 0,
+                "exempted turn must still METER (got 0 computrons_used)"
+            );
+            assert_eq!(
+                receipt.computrons_used, computrons_used,
+                "receipt must carry the same honest metering"
+            );
+        }
+        other => panic!("expected commit, got {other:?}"),
+    }
+}
+
+#[test]
+fn estimate_and_validate_mirror_the_exemption() {
+    let agent = make_open_cell(1, 0);
+    let agent_id = agent.id();
+    let mut ledger = Ledger::new();
+    ledger.insert_cell(agent).unwrap();
+
+    let exempt = exempt_executor();
+    let legacy = TurnExecutor::new(ComputronCosts::default_costs());
+    let chat = chat_turn(agent_id, 0);
+    let transfer = transfer_turn(agent_id, make_open_cell(2, 0).id(), 1, 0);
+
+    assert_eq!(exempt.estimate_cost(&chat), 0, "exempt coordination estimates 0");
+    assert!(legacy.estimate_cost(&chat) > 0, "legacy estimate unchanged");
+    assert!(
+        exempt.estimate_cost(&transfer) > 0,
+        "economic turns estimate real cost even under exempt"
+    );
+
+    assert!(
+        exempt.validate_without_apply(&chat, &ledger).is_ok(),
+        "exempt fee=0 coordination turn validates"
+    );
+    assert!(
+        matches!(
+            legacy.validate_without_apply(&chat, &ledger),
+            Err(TurnError::BudgetExceeded { .. })
+        ),
+        "legacy fee=0 coordination turn fails validation"
+    );
+}
+
+#[test]
+fn exempt_turn_with_nonzero_fee_still_commits_and_charges() {
+    // Opting in does not FORBID a fee: a funded cell may still attach one
+    // (it is debited and distributed exactly as before).
+    let agent = make_open_cell(1, 10_000);
+    let agent_id = agent.id();
+    let mut ledger = Ledger::new();
+    ledger.insert_cell(agent).unwrap();
+
+    let executor = exempt_executor();
+    let turn = chat_turn(agent_id, 1_000);
+    let result = executor.execute(&turn, &mut ledger);
+    assert!(result.is_committed(), "funded exempt turn commits: {result:?}");
+    let balance = ledger.get(&agent_id).unwrap().state.balance();
+    assert_eq!(
+        balance, 9_000,
+        "an attached fee is still debited (fee stays a real move when carried)"
+    );
+}

--- a/turn/tests/faucet_steady_state_solvency.rs
+++ b/turn/tests/faucet_steady_state_solvency.rs
@@ -1,0 +1,507 @@
+//! THE FEE LOOP (revolving fund) steady-state solvency property.
+//!
+//! Models the harness of `turn/tests/conservation_burn_property.rs` (`open_cell`
+//! + `TurnExecutor`), but for the DEPLOYED drain: on a genesis-less devnet cave
+//! node the fee well was a PURE SINK — `distribute_fee_shares` credited the
+//! undelivered fee remainder into a cell nothing ever moved value OUT of — while
+//! the faucet, a pure payer-out, drained monotonically on every agent top-up.
+//! ~800 fee-bearing turns later: "insufficient balance on cell <id>: need 1254,
+//! have <X>" → signing DEGRADED.
+//!
+//! THE FIX (proven load-bearing here): point the executor's fee well AT the
+//! faucet cell (`set_fee_well_cell(faucet_id)`), so every committed turn's
+//! `fee - delivered` credit recirculates straight back into the pool the faucet
+//! pays out of. NO fee is zeroed — the per-turn debit remains the oversight
+//! leash. Two invariants, both asserted:
+//!   (1) PER-TURN: Σ(balance_change over every cell) == 0 — no ex-nihilo mint or
+//!       burn on any committed turn.
+//!   (2) STANDING (closed system): Σ(faucet + every agent) == const across N
+//!       turns, because the fee no longer escapes to a dead sink.
+//! The CONTROL (`fee_well` UNSET) reproduces the drain — locking in that the
+//! pointer change is the CAUSE of solvency.
+//!
+//! HARNESS NOTE: like `conservation_burn_property.rs`, each `execute()` runs on
+//! a FRESH `TurnExecutor` (`run_turn`) — the executor enforces per-agent receipt
+//! chaining (`check_previous_receipt_hash`), and cell nonces / balances live on
+//! the LEDGER, which persists across executors. This isolates the value
+//! invariants (the subject under test) from receipt-chain bookkeeping.
+
+use dregg_cell::{AuthRequired, Cell, CellId, Ledger, Permissions};
+use dregg_turn::{
+    Action, Authorization, CallForest, ComputronCosts, DelegationMode, Effect, TurnExecutor,
+    turn::{Turn, TurnResult},
+};
+
+/// The observed real per-turn coordination fee on the deployed chain.
+const FEE: u64 = 1254;
+
+fn open_permissions() -> Permissions {
+    Permissions {
+        send: AuthRequired::None,
+        receive: AuthRequired::None,
+        set_state: AuthRequired::None,
+        set_permissions: AuthRequired::None,
+        set_verification_key: AuthRequired::None,
+        increment_nonce: AuthRequired::None,
+        delegate: AuthRequired::None,
+        access: AuthRequired::None,
+    }
+}
+
+/// An open hosted cell (default asset) with a chosen balance.
+fn open_cell(seed: u8, balance: i64) -> Cell {
+    let mut pk = [0u8; 32];
+    pk[0] = seed;
+    pk[31] = seed.wrapping_mul(37).wrapping_add(1);
+    let mut cell = Cell::with_balance(pk, [0u8; 32], balance);
+    cell.permissions = open_permissions();
+    cell
+}
+
+fn base_action(target: CellId, effects: Vec<Effect>) -> Action {
+    Action {
+        target,
+        method: [0u8; 32],
+        args: vec![],
+        authorization: Authorization::Unchecked,
+        preconditions: Default::default(),
+        effects,
+        may_delegate: DelegationMode::None,
+        commitment_mode: Default::default(),
+        balance_change: None,
+        witness_blobs: vec![],
+    }
+}
+
+fn base_turn(agent: CellId, nonce: u64, fee: u64, effects: Vec<Effect>) -> Turn {
+    let mut forest = CallForest::new();
+    forest.add_root(base_action(agent, effects));
+    Turn {
+        agent,
+        nonce,
+        call_forest: forest,
+        fee,
+        memo: None,
+        valid_until: None,
+        previous_receipt_hash: None,
+        depends_on: vec![],
+        conservation_proof: None,
+        sovereign_witnesses: std::collections::HashMap::new(),
+        execution_proof: None,
+        execution_proof_cell: None,
+        execution_proof_new_commitment: None,
+        custom_program_proofs: None,
+        effect_binding_proofs: Vec::new(),
+        cross_effect_dependencies: Vec::new(),
+        effect_witness_index_map: Vec::new(),
+    }
+}
+
+/// A fee-bearing COORDINATION turn: an empty-effects action (the ~99% a2a-chat
+/// workload). It commits, debits `fee` from the agent, and — with the well set —
+/// credits `fee` to the faucet.
+fn coordination_turn(agent: CellId, nonce: u64, fee: u64) -> Turn {
+    base_turn(agent, nonce, fee, vec![])
+}
+
+/// The faucet's OWN top-up turn: agent == faucet, a Transfer of `amount` to the
+/// recipient. Fee-bearing like any turn; with well == faucet the -fee/+fee legs
+/// net zero, so the faucet's net per top-up is exactly -amount.
+fn faucet_topup_turn(faucet: CellId, recipient: CellId, nonce: u64, fee: u64, amount: u64) -> Turn {
+    base_turn(
+        faucet,
+        nonce,
+        fee,
+        vec![Effect::Transfer {
+            from: faucet,
+            to: recipient,
+            amount,
+        }],
+    )
+}
+
+/// Run one turn on a fresh executor with an optional fee well. See HARNESS NOTE.
+fn run_turn(ledger: &mut Ledger, turn: &Turn, fee_well: Option<CellId>) -> TurnResult {
+    let mut executor = TurnExecutor::new(ComputronCosts::zero());
+    if let Some(well) = fee_well {
+        executor.set_fee_well_cell(well);
+    }
+    executor.execute(turn, ledger)
+}
+
+/// Snapshot every cell's balance keyed by id.
+fn balances(ledger: &Ledger) -> std::collections::HashMap<CellId, i64> {
+    ledger
+        .iter()
+        .map(|(id, c)| (*id, c.state.balance()))
+        .collect()
+}
+
+/// Sum of ALL per-cell balance deltas across the whole ledger (any lazily-created
+/// cell appears as a delta from 0).
+fn total_delta(
+    before: &std::collections::HashMap<CellId, i64>,
+    after: &std::collections::HashMap<CellId, i64>,
+) -> i128 {
+    let mut keys: std::collections::HashSet<&CellId> = before.keys().collect();
+    keys.extend(after.keys());
+    keys.into_iter()
+        .map(|k| {
+            let b = before.get(k).copied().unwrap_or(0) as i128;
+            let a = after.get(k).copied().unwrap_or(0) as i128;
+            a - b
+        })
+        .sum()
+}
+
+/// Whole-ledger balance sum (the standing closed-system total).
+fn ledger_total(ledger: &Ledger) -> i128 {
+    ledger.iter().map(|(_, c)| c.state.balance() as i128).sum()
+}
+
+fn bal(ledger: &Ledger, id: &CellId) -> i64 {
+    ledger.get(id).unwrap().state.balance()
+}
+
+// =============================================================================
+// UNIT: per-turn conservation + the faucet is credited exactly (fee - delivered)
+// on every coordination turn, so it can never trend to zero under load.
+// =============================================================================
+#[test]
+fn unit_fee_well_is_faucet_credits_each_coordination_turn() {
+    let agent = open_cell(1, 1_000_000);
+    let faucet = open_cell(2, 1_000_000);
+    let agent_id = agent.id();
+    let faucet_id = faucet.id();
+
+    let mut ledger = Ledger::new();
+    ledger.insert_cell(agent).unwrap();
+    ledger.insert_cell(faucet).unwrap();
+
+    // No proposer / treasury configured → delivered == 0 → the whole fee moves
+    // to the well (== faucet) on every turn.
+    let delivered: u64 = 0;
+    let per_turn_credit = FEE - delivered;
+
+    let n = 500u64;
+    for nonce in 0..n {
+        let faucet_before = bal(&ledger, &faucet_id);
+        let agent_before = bal(&ledger, &agent_id);
+        let before = balances(&ledger);
+
+        let result = run_turn(
+            &mut ledger,
+            &coordination_turn(agent_id, nonce, FEE),
+            Some(faucet_id),
+        );
+        assert!(
+            matches!(result, TurnResult::Committed { .. }),
+            "coordination turn {nonce} must commit: {result:?}"
+        );
+
+        let after = balances(&ledger);
+        // (1) PER-TURN CONSERVATION.
+        assert_eq!(
+            total_delta(&before, &after),
+            0,
+            "per-turn Σδ must be zero on turn {nonce} (agent -fee == faucet +fee)"
+        );
+        // The faucet gained exactly (fee - delivered).
+        assert_eq!(
+            bal(&ledger, &faucet_id),
+            faucet_before + per_turn_credit as i64,
+            "faucet credited exactly (fee - delivered) on turn {nonce}"
+        );
+        // The agent paid exactly fee.
+        assert_eq!(
+            bal(&ledger, &agent_id),
+            agent_before - FEE as i64,
+            "agent debited exactly fee on turn {nonce}"
+        );
+    }
+
+    // After N turns the faucet is UP by N*fee, not drained.
+    assert_eq!(
+        bal(&ledger, &faucet_id),
+        1_000_000 + (n * per_turn_credit) as i64,
+        "faucet accrued every coordination fee — the opposite of draining"
+    );
+}
+
+// =============================================================================
+// INTEGRATION: closed-loop sim over N=10_000 coordination turns with faucet
+// top-ups. The standing total is invariant and the faucet holds a positive
+// floor — it NEVER hits the 'need <fee>, have <X>' insufficient-balance wall.
+// =============================================================================
+#[test]
+fn integration_closed_loop_solvent_over_10k_turns() {
+    const FAUCET_START: i64 = 1_000_000;
+    const AGENT_BUFFER: u64 = 50_000; // the agent's working balance target
+
+    let agent = open_cell(3, AGENT_BUFFER as i64);
+    let faucet = open_cell(4, FAUCET_START);
+    let agent_id = agent.id();
+    let faucet_id = faucet.id();
+
+    let mut ledger = Ledger::new();
+    ledger.insert_cell(agent).unwrap();
+    ledger.insert_cell(faucet).unwrap();
+
+    let standing_before = ledger_total(&ledger);
+    assert_eq!(standing_before, FAUCET_START + AGENT_BUFFER as i64);
+
+    let mut agent_nonce = 0u64;
+    let mut faucet_nonce = 0u64;
+    // Fees the faucet has skimmed back since the last top-up — the amount it
+    // returns to the agent so the loop reaches exact steady state.
+    let mut skim_since_topup: u64 = 0;
+    let mut floor = i64::MAX;
+
+    let turns = 10_000u64;
+    for _ in 0..turns {
+        // Top up the agent BEFORE it would fall below one fee — modeling the
+        // real faucet, funded from fees it accrued since the last top-up.
+        if bal(&ledger, &agent_id) < FEE as i64 {
+            // Return EXACTLY the fees skimmed since the last top-up: agent +
+            // skim is invariant between top-ups, so this restores the agent to
+            // its post-previous-top-up level and the faucet nets zero per cycle
+            // (true steady state).
+            let amount = skim_since_topup;
+            let before = balances(&ledger);
+            let r = run_turn(
+                &mut ledger,
+                &faucet_topup_turn(faucet_id, agent_id, faucet_nonce, FEE, amount),
+                Some(faucet_id),
+            );
+            assert!(
+                matches!(r, TurnResult::Committed { .. }),
+                "faucet top-up must commit (faucet solvent): {r:?}"
+            );
+            faucet_nonce += 1;
+            skim_since_topup = 0;
+            // The top-up turn is itself conservation-closed (fee legs net zero,
+            // Transfer moves `amount`).
+            assert_eq!(
+                total_delta(&before, &balances(&ledger)),
+                0,
+                "faucet top-up turn must be conservation-closed (Σδ == 0)"
+            );
+        }
+
+        // One coordination turn: agent -fee, faucet +fee.
+        let r = run_turn(
+            &mut ledger,
+            &coordination_turn(agent_id, agent_nonce, FEE),
+            Some(faucet_id),
+        );
+        assert!(
+            matches!(r, TurnResult::Committed { .. }),
+            "coordination turn must commit — the agent is never starved: {r:?}"
+        );
+        agent_nonce += 1;
+        skim_since_topup += FEE;
+
+        floor = floor.min(bal(&ledger, &faucet_id));
+    }
+
+    // (2) STANDING INVARIANT: the closed {faucet + agent} total is unchanged.
+    assert_eq!(
+        ledger_total(&ledger),
+        standing_before,
+        "standing total must be invariant across {turns} turns (no dead sink)"
+    );
+    // The faucet held a strictly POSITIVE floor and never approached zero: the
+    // deepest dip is bounded by the agent's working buffer, not by the run
+    // length. THIS is the property the drain violated.
+    assert!(
+        floor >= FAUCET_START - AGENT_BUFFER as i64 - FEE as i64,
+        "faucet floor {floor} must stay near start (bounded by the agent buffer, not turn count)"
+    );
+    assert!(floor > 0, "faucet never insolvent (floor {floor} > 0)");
+}
+
+// =============================================================================
+// CONTROL / REGRESSION: the IDENTICAL loop with the fee well UNSET. The fee is
+// now BURNED every coordination turn (debited from the agent, credited nowhere),
+// so the closed total bleeds away and the faucet drains monotonically to
+// insolvency. Proves the pointer change is the CAUSE of solvency.
+// =============================================================================
+#[test]
+fn control_no_fee_well_drains_faucet_to_insolvency() {
+    const FAUCET_START: i64 = 1_000_000;
+    const AGENT_BUFFER: u64 = 50_000;
+
+    let agent = open_cell(5, AGENT_BUFFER as i64);
+    let faucet = open_cell(6, FAUCET_START);
+    let agent_id = agent.id();
+    let faucet_id = faucet.id();
+
+    let mut ledger = Ledger::new();
+    ledger.insert_cell(agent).unwrap();
+    ledger.insert_cell(faucet).unwrap();
+
+    let standing_before = ledger_total(&ledger);
+
+    let mut agent_nonce = 0u64;
+    let mut faucet_nonce = 0u64;
+    let mut last_faucet = FAUCET_START;
+    let mut monotone_nonincreasing = true;
+    let mut insolvency_turn: Option<u64> = None;
+
+    // A generous bound: the faucet MUST go insolvent well within this many turns
+    // (FAUCET_START / FEE ≈ 797 fee-burns' worth of runway).
+    let cap = 5_000u64;
+    for t in 0..cap {
+        // Fund the agent when it can't cover a fee, IF the faucet still can.
+        if bal(&ledger, &agent_id) < FEE as i64 {
+            if bal(&ledger, &faucet_id) < (AGENT_BUFFER + FEE) as i64 {
+                // Faucet can no longer fund a full buffer + its own fee: the
+                // observed "insufficient balance ... need <fee>" wall.
+                insolvency_turn = Some(t);
+                break;
+            }
+            // NO fee well — fees BURN, so the faucet is never replenished.
+            let r = run_turn(
+                &mut ledger,
+                &faucet_topup_turn(faucet_id, agent_id, faucet_nonce, FEE, AGENT_BUFFER),
+                None,
+            );
+            assert!(matches!(r, TurnResult::Committed { .. }), "top-up: {r:?}");
+            faucet_nonce += 1;
+        }
+
+        let r = run_turn(
+            &mut ledger,
+            &coordination_turn(agent_id, agent_nonce, FEE),
+            None,
+        );
+        assert!(matches!(r, TurnResult::Committed { .. }), "coord: {r:?}");
+        agent_nonce += 1;
+
+        let f = bal(&ledger, &faucet_id);
+        if f > last_faucet {
+            monotone_nonincreasing = false; // the well-less faucet only ever loses value
+        }
+        last_faucet = f;
+    }
+
+    // The closed total STRICTLY DECREASED — value escaped to the burn sink.
+    assert!(
+        ledger_total(&ledger) < standing_before,
+        "well-less: standing total must bleed (fees burned, not recirculated)"
+    );
+    // The faucet trended monotonically down and reached the insolvency wall.
+    assert!(
+        monotone_nonincreasing,
+        "well-less faucet must only ever lose value (monotone non-increasing)"
+    );
+    assert!(
+        insolvency_turn.is_some(),
+        "well-less faucet MUST hit the insufficient-balance wall within {cap} turns"
+    );
+}
+
+// =============================================================================
+// PROPERTY: over randomized fee / top-up schedules (deterministic LCG so it is
+// reproducible without a proptest dependency), the fee-well-as-faucet loop keeps
+// the faucet bounded BELOW by a positive constant — steady-state, not draining —
+// and every turn stays conservation-closed.
+// =============================================================================
+#[test]
+fn property_randomized_schedule_faucet_bounded_below() {
+    const FAUCET_START: i64 = 2_000_000;
+    const AGENT_START: i64 = 200_000;
+
+    // Simple reproducible LCG (Numerical Recipes constants).
+    let mut rng: u64 = 0x9E3779B97F4A7C15;
+    let mut next = || {
+        rng = rng
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (rng >> 33) as u64
+    };
+
+    let agent = open_cell(7, AGENT_START);
+    let faucet = open_cell(8, FAUCET_START);
+    let agent_id = agent.id();
+    let faucet_id = faucet.id();
+
+    let mut ledger = Ledger::new();
+    ledger.insert_cell(agent).unwrap();
+    ledger.insert_cell(faucet).unwrap();
+
+    let standing_before = ledger_total(&ledger);
+
+    let mut agent_nonce = 0u64;
+    let mut faucet_nonce = 0u64;
+    let mut skim_since_topup: u64 = 0;
+    let mut floor = i64::MAX;
+
+    for _ in 0..8_000u64 {
+        // Randomized fee in a plausible coordination band [200, 2000].
+        let fee = 200 + next() % 1801;
+
+        // Randomized top-up policy: sometimes refill early, sometimes only when
+        // forced. Never let the agent starve (that would just reject, not drain).
+        let refill_threshold = (fee as i64) * (1 + (next() % 5) as i64);
+        if skim_since_topup > 0 && bal(&ledger, &agent_id) < refill_threshold {
+            // Return EXACTLY the fees skimmed since the last top-up. agent +
+            // skim is invariant between top-ups (each coordination turn moves
+            // fee from agent to skim), so this restores the agent to its
+            // post-previous-top-up level (>= AGENT_START) and the faucet nets
+            // zero per cycle — steady state under ANY schedule.
+            let amount = skim_since_topup;
+            if bal(&ledger, &faucet_id) >= (amount + fee) as i64 {
+                let before = balances(&ledger);
+                let r = run_turn(
+                    &mut ledger,
+                    &faucet_topup_turn(faucet_id, agent_id, faucet_nonce, fee, amount),
+                    Some(faucet_id),
+                );
+                assert!(matches!(r, TurnResult::Committed { .. }), "topup: {r:?}");
+                faucet_nonce += 1;
+                skim_since_topup = 0;
+                assert_eq!(
+                    total_delta(&before, &balances(&ledger)),
+                    0,
+                    "randomized top-up turn must be conservation-closed"
+                );
+            }
+        }
+
+        if bal(&ledger, &agent_id) < fee as i64 {
+            continue; // skip this coordination turn; agent momentarily short
+        }
+        let before = balances(&ledger);
+        let r = run_turn(
+            &mut ledger,
+            &coordination_turn(agent_id, agent_nonce, fee),
+            Some(faucet_id),
+        );
+        assert!(matches!(r, TurnResult::Committed { .. }), "coord: {r:?}");
+        agent_nonce += 1;
+        skim_since_topup += fee;
+
+        assert_eq!(
+            total_delta(&before, &balances(&ledger)),
+            0,
+            "randomized coordination turn must be conservation-closed (Σδ == 0)"
+        );
+
+        floor = floor.min(bal(&ledger, &faucet_id));
+    }
+
+    // STANDING INVARIANT holds under any schedule.
+    assert_eq!(
+        ledger_total(&ledger),
+        standing_before,
+        "standing total invariant under randomized schedule"
+    );
+    // Faucet bounded below by a positive constant: the deepest it can dip is one
+    // agent top-up cycle, independent of the 8000-turn length.
+    assert!(
+        floor >= FAUCET_START - AGENT_START - 100_000,
+        "faucet bounded below (floor {floor}) — steady-state, not draining"
+    );
+    assert!(floor > 0, "faucet never insolvent under randomized schedule");
+}

--- a/turn/tests/faucet_steady_state_solvency.rs
+++ b/turn/tests/faucet_steady_state_solvency.rs
@@ -248,7 +248,8 @@ fn integration_closed_loop_solvent_over_10k_turns() {
     ledger.insert_cell(faucet).unwrap();
 
     let standing_before = ledger_total(&ledger);
-    assert_eq!(standing_before, FAUCET_START + AGENT_BUFFER as i64);
+    // ledger_total() is i128 (real Ledger balances are i128) — match the width.
+    assert_eq!(standing_before, FAUCET_START as i128 + AGENT_BUFFER as i128);
 
     let mut agent_nonce = 0u64;
     let mut faucet_nonce = 0u64;


### PR DESCRIPTION
## What this fixes, and how we found it

A coordination-exempt join still walks into the faucet on the one path that
matters: the **first** join, where the cell does not exist yet.

`ensure_cell` computes `funding_shortfall(initial, minimum_balance,
target_balance)` and returns early only on `!materialized && shortfall == 0`.
An ABSENT cell is `materialized`, so it always POSTs — with `amount: shortfall`,
which derives from **target**. Setting only the minimum to 0 left target at
`f.fund` (5000), so the POST still requested a funded grant.

## Dogfood evidence (this is why we are sending it)

We run a multi-agent fleet whose chat transport is client-signed through
`dregg-client-sign` against a genesis-less devnet cave node. On 2026-07-28 the
`david` profile's join failed and the transport sat DEGRADED for ~20 hours:

```
[client-sign] error: faucet grant was already in flight but cell 69d709b0…
did not reach 5000 computrons within 10s:
{"amount":0,"error":"rate limited: 1 request per cell per minute","success":false}
```

Note the shape: the client waits **10 seconds**, the faucet rate-limits to
**1 request per cell per minute**. The client's patience is shorter than the
server's minimum retry interval, so a contended faucet can never succeed — the
join is not slow, it is unable to complete by construction.

Cell balances at the time, which show the same race across the fleet:
`codex 5000` (won the race once), `ds4pro 0`, `gemini 0`, `helm-claude-2 0`.

**After building this branch**, the failure mode moves past the faucet timeout
entirely — the 10s/60s trap is gone. What we hit next is a separate, node-side
issue we have not fixed here:

```
[client-sign] error: faucet refused funding:
{"error":"transfer rejected: invalid authorization: hybrid: Ed25519 (classical) signature half failed"}
```

so this branch is necessary but, in our deployment, not yet sufficient — the
exempt join still reaches the faucet at all, which suggests the node half
(`feat(fee): turn ON the coordination class on the genesis-less devnet`) is not
active on our running node. Flagging that honestly rather than claiming a green.

## Branch contents

The branch carries the fee-exempt coordination work it sits on; `f432a8e22` is
the one-line-class fix above. Happy to rebase, split, or reduce to just that
commit — say which shape you want.

Built and exercised on our fork at `akapug/dregg`.