### PR TITLE
fix(node/mcp): bound tool_submit_turn's unbounded valid_until

### DIFF
--- a/node/src/api.rs
+++ b/node/src/api.rs
@@ -5013,7 +5013,8 @@ pub(crate) async fn enqueue_async_proof(
 const DEFAULT_TURN_VALIDITY_HORIZON_SECS: i64 = 3600;
 
 /// Default `valid_until` for turns the node constructs itself (the thin-HTTP
-/// `/turn/submit` and faucet paths).
+/// `/turn/submit` and faucet paths, plus `mcp::handlers_act::tool_submit_turn` —
+/// see that call site for why this is `pub(crate)`).
 ///
 /// The Lean producer's wire marshal REQUIRES the turn envelope's `valid_until`
 /// (`lean_shadow::turn_to_wire_turn`); a `None` here meant every thin-HTTP turn
@@ -5022,7 +5023,7 @@ const DEFAULT_TURN_VALIDITY_HORIZON_SECS: i64 = 3600;
 /// executor enforces `current_timestamp <= valid_until` (a TIMESTAMP deadline,
 /// not a height), so the default is wall-clock now + a horizon — never a block
 /// height, which would be in the past as a timestamp and expire every turn.
-fn default_valid_until() -> Option<i64> {
+pub(crate) fn default_valid_until() -> Option<i64> {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
@@ -10990,6 +10991,91 @@ struct QueueAtomicTxResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `default_valid_until` is `pub(crate)` specifically so
+    /// `mcp::handlers_act::tool_submit_turn` can reuse it instead of stamping
+    /// `valid_until: None` (see that call site's comment). This pins the property
+    /// that actually matters at every one of its call sites: with `None`, the Rust
+    /// executor's expiration check (`turn/src/executor/execute.rs:426`,
+    /// `if let Some(valid_until) = turn.valid_until { ... }`) is SKIPPED entirely —
+    /// a turn built from a `None` sentinel never expires, no matter how stale.
+    /// `default_valid_until()` must stay `Some`, and — the part a bare `is_some()`
+    /// check cannot catch — a turn stamped from it must still be REJECTED once its
+    /// horizon has actually passed, proving the field is wired to the executor's
+    /// enforcement and not merely non-`None`.
+    ///
+    /// (Note this only pins the expiration leg. It does NOT claim `tool_submit_turn`
+    /// now runs on the verified Lean producer: that handler's turns carry an empty
+    /// `effects` list, which fails `forest_is_marshallable` independently of
+    /// `valid_until` — a separate, larger gap this change does not touch.)
+    #[test]
+    fn default_valid_until_is_some_and_an_expired_stamp_is_still_rejected() {
+        assert!(
+            default_valid_until().is_some(),
+            "a None here means every turn built from it never expires (the executor skips \
+             the check entirely on None, turn/src/executor/execute.rs:426) — the sentinel \
+             must always be Some"
+        );
+
+        let mut agent = dregg_cell::Cell::with_balance([9u8; 32], [0u8; 32], 100);
+        agent.permissions = dregg_cell::Permissions {
+            send: dregg_cell::AuthRequired::None,
+            receive: dregg_cell::AuthRequired::None,
+            set_state: dregg_cell::AuthRequired::None,
+            set_permissions: dregg_cell::AuthRequired::None,
+            set_verification_key: dregg_cell::AuthRequired::None,
+            increment_nonce: dregg_cell::AuthRequired::None,
+            delegate: dregg_cell::AuthRequired::None,
+            access: dregg_cell::AuthRequired::None,
+        };
+        let agent_id = agent.id();
+        let mut ledger = dregg_cell::Ledger::new();
+        ledger.insert_cell(agent).expect("insert test agent cell");
+
+        let action = dregg_turn::Action {
+            target: agent_id,
+            method: [0u8; 32],
+            args: vec![],
+            authorization: dregg_turn::Authorization::Unchecked,
+            preconditions: Default::default(),
+            effects: vec![],
+            may_delegate: dregg_turn::DelegationMode::None,
+            commitment_mode: Default::default(),
+            balance_change: None,
+            witness_blobs: vec![],
+        };
+        let mut forest = CallForest::new();
+        forest.add_root(action);
+        let turn = Turn {
+            agent: agent_id,
+            nonce: 0,
+            call_forest: forest,
+            fee: 0,
+            memo: None,
+            valid_until: Some(1), // one second past the UNIX epoch — always in the past
+            previous_receipt_hash: None,
+            depends_on: vec![],
+            conservation_proof: None,
+            sovereign_witnesses: std::collections::HashMap::new(),
+            execution_proof: None,
+            execution_proof_cell: None,
+            execution_proof_new_commitment: None,
+            custom_program_proofs: None,
+            effect_binding_proofs: Vec::new(),
+            cross_effect_dependencies: Vec::new(),
+            effect_witness_index_map: Vec::new(),
+        };
+
+        let mut executor = dregg_turn::TurnExecutor::new(dregg_turn::ComputronCosts::zero());
+        executor.set_timestamp(2_000_000_000); // 2033-ish — well past the stamped deadline
+        let result = executor.execute(&turn, &mut ledger);
+        assert!(
+            !result.is_committed(),
+            "a turn stamped with an already-expired valid_until must be REJECTED, not \
+             committed — if this fires, the deadline check in \
+             turn/src/executor/execute.rs stopped enforcing valid_until: {result:?}"
+        );
+    }
 
     /// ⚑ THE JOINER POLE OF `/status`. Measured 2026-08-09 on port 8465: a node
     /// that asked to join and was refused for 345 s reported `"healthy": true`

--- a/node/src/mcp/handlers_act.rs
+++ b/node/src/mcp/handlers_act.rs
@@ -193,12 +193,25 @@ pub(super) async fn tool_submit_turn(params: &Value, state: &NodeState) -> McpTo
     // swapping the accessor alone would only move the failure to this agent's SECOND
     // turn.
     let previous_receipt_hash = s.cclerk.agent_receipt_head_hash(&agent_cell_id);
+    // `valid_until: None` means the Rust executor's expiration check is SKIPPED entirely
+    // (`if let Some(valid_until) = turn.valid_until { ... }`, executor/execute.rs:426) — a
+    // turn built here never expires, no matter how stale. Bound it with the node's own
+    // default rather than a third copy of the wall-clock-horizon logic; mirrors the same
+    // fix already applied to the thin-HTTP `/turn/submit` path (`api::default_valid_until`)
+    // and the SDK (`dregg_sdk::runtime::default_valid_until`, issue #46).
+    //
+    // NOTE: this does NOT make `submit_turn` reach the verified Lean producer. This
+    // handler always builds an empty `action.effects` (below), which fails
+    // `lean_shadow::forest_is_marshallable` on its own — independently of `valid_until` —
+    // so `mcp_execute_via_producer` still fences every call onto the demoted Rust
+    // reference today. That is a separate, larger gap (this tool has no way to carry
+    // caller-specified effects yet); fixing the unbounded expiry here does not fix it.
     let turn = Turn {
         agent: agent_cell_id,
         nonce,
         fee,
         memo,
-        valid_until: None,
+        valid_until: crate::api::default_valid_until(),
         call_forest: forest,
         depends_on: vec![],
         previous_receipt_hash,


### PR DESCRIPTION
## What

`mcp::handlers_act::tool_submit_turn` builds its `Turn` with `valid_until: None`. The Rust executor's expiration check is a plain `if let Some(valid_until) = turn.valid_until { ... }` (`turn/src/executor/execute.rs:426`) — with `None` that check is skipped entirely, so every turn this MCP tool submits never expires, no matter how stale.

This mirrors the same defect already fixed at two other call sites: the thin-HTTP `/turn/submit` path (`api::default_valid_until`, preexisting) and the SDK (`dregg_sdk::runtime::default_valid_until`, #46). This PR makes `default_valid_until` `pub(crate)` and reuses it at this third site, instead of adding a fourth copy of the wall-clock-horizon logic.

## Test

Added `default_valid_until_is_some_and_an_expired_stamp_is_still_rejected` in `node/src/api.rs`, pinning two things:
1. the sentinel itself must stay `Some` (a bare regression guard), and
2. a turn stamped with an already-expired `valid_until` is actually rejected by the bare Rust executor — proving the field is wired to real enforcement, not merely non-`None`.

```
cargo test -p dregg-node --lib api::tests::default_valid_until
  → 1 passed

DREGG_TEST_ALLOW_MISSING_LEAN=1 DREGG_ALLOW_UNAUDITED_PQ=1 \
  cargo test -p dregg-node --lib mcp::
  → 48 passed, 0 failed, no regressions
  (env vars are this local environment's workaround for the unlinked verified
  PQ/Lean cores — not part of the change)
```

## Scope note (checked, not assumed)

This does **not** make `tool_submit_turn` reach the verified Lean producer. That handler always builds an empty `action.effects` list, which fails `lean_shadow::forest_is_marshallable` on its own — independently of `valid_until` — so `mcp_execute_via_producer` still fences every `submit_turn` call onto the demoted Rust reference today (confirmed empirically: an eligibility probe against this exact turn shape returns `Fallback { reason: "turn forest not fully marshallable — no verified post-state to install" }` regardless of `valid_until`). That's a separate, larger gap — this tool has no way to carry caller-specified effects yet — and this PR does not touch it. Said directly in the call-site comment so it doesn't get overclaimed later.

Related: #78 (SDK), #79 (mirror-gates baseline).
