### PR TITLE
fix(node/mcp): bound the unbounded valid_until on 11 more Turn literals

### DIFF
--- a/node/src/api.rs
+++ b/node/src/api.rs
@@ -5022,7 +5022,7 @@ const DEFAULT_TURN_VALIDITY_HORIZON_SECS: i64 = 3600;
 /// executor enforces `current_timestamp <= valid_until` (a TIMESTAMP deadline,
 /// not a height), so the default is wall-clock now + a horizon — never a block
 /// height, which would be in the past as a timestamp and expire every turn.
-fn default_valid_until() -> Option<i64> {
+pub(crate) fn default_valid_until() -> Option<i64> {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)

--- a/node/src/mcp/handlers_act.rs
+++ b/node/src/mcp/handlers_act.rs
@@ -193,12 +193,25 @@ pub(super) async fn tool_submit_turn(params: &Value, state: &NodeState) -> McpTo
     // swapping the accessor alone would only move the failure to this agent's SECOND
     // turn.
     let previous_receipt_hash = s.cclerk.agent_receipt_head_hash(&agent_cell_id);
+    // `valid_until: None` means the Rust executor's expiration check is SKIPPED entirely
+    // (`if let Some(valid_until) = turn.valid_until { ... }`, executor/execute.rs:426) — a
+    // turn built here never expires, no matter how stale. Bound it with the node's own
+    // default rather than a third copy of the wall-clock-horizon logic; mirrors the same
+    // fix already applied to the thin-HTTP `/turn/submit` path (`api::default_valid_until`)
+    // and the SDK (`dregg_sdk::runtime::default_valid_until`, issue #46).
+    //
+    // NOTE: this does NOT make `submit_turn` reach the verified Lean producer. This
+    // handler always builds an empty `action.effects` (below), which fails
+    // `lean_shadow::forest_is_marshallable` on its own — independently of `valid_until` —
+    // so `mcp_execute_via_producer` still fences every call onto the demoted Rust
+    // reference today. That is a separate, larger gap (this tool has no way to carry
+    // caller-specified effects yet); fixing the unbounded expiry here does not fix it.
     let turn = Turn {
         agent: agent_cell_id,
         nonce,
         fee,
         memo,
-        valid_until: None,
+        valid_until: crate::api::default_valid_until(),
         call_forest: forest,
         depends_on: vec![],
         previous_receipt_hash,
@@ -919,7 +932,13 @@ pub(super) async fn tool_captp_deliver(params: &Value, state: &NodeState) -> Mcp
         nonce: turn_nonce,
         fee: 10_000,
         memo: Some("captp.route (mcp)".to_string()),
-        valid_until: None,
+        // `valid_until: None` skips the executor's expiration check entirely
+        // (`if let Some(valid_until) = turn.valid_until { ... }`,
+        // `turn/src/executor/execute.rs:426`) — a turn built that way never expires,
+        // no matter how stale. Bound it with the node's own default instead
+        // (`api::default_valid_until`), same fix already applied to the thin-HTTP
+        // `/turn/submit` path.
+        valid_until: crate::api::default_valid_until(),
         call_forest: forest,
         depends_on: vec![],
         previous_receipt_hash,
@@ -1182,7 +1201,13 @@ pub(super) async fn tool_bilateral_action(params: &Value, state: &NodeState) -> 
         nonce: turn_nonce,
         fee: 10_000,
         memo: Some(format!("bilateral {mode}")),
-        valid_until: None,
+        // `valid_until: None` skips the executor's expiration check entirely
+        // (`if let Some(valid_until) = turn.valid_until { ... }`,
+        // `turn/src/executor/execute.rs:426`) — a turn built that way never expires,
+        // no matter how stale. Bound it with the node's own default instead
+        // (`api::default_valid_until`), same fix already applied to the thin-HTTP
+        // `/turn/submit` path.
+        valid_until: crate::api::default_valid_until(),
         call_forest: forest,
         depends_on: vec![],
         previous_receipt_hash,

--- a/node/src/mcp/handlers_apps.rs
+++ b/node/src/mcp/handlers_apps.rs
@@ -249,7 +249,10 @@ pub(super) async fn tool_create_cell_from_factory_effect(
         nonce,
         fee: 10_000,
         memo: Some("create cell from factory (mcp)".to_string()),
-        valid_until: None,
+        // `None` skips the executor's expiration check entirely
+        // (`turn/src/executor/execute.rs:426`) — bound it instead
+        // (`api::default_valid_until`).
+        valid_until: crate::api::default_valid_until(),
         call_forest: build_signed_forest(
             agent_cell_id,
             vec![effect],
@@ -426,7 +429,10 @@ pub(super) async fn run_starbridge_action(
         nonce,
         fee: 10_000,
         memo: Some(memo),
-        valid_until: None,
+        // `None` skips the executor's expiration check entirely
+        // (`turn/src/executor/execute.rs:426`) — bound it instead
+        // (`api::default_valid_until`).
+        valid_until: crate::api::default_valid_until(),
         call_forest: forest,
         depends_on: vec![],
         previous_receipt_hash,

--- a/node/src/mcp/handlers_delegate.rs
+++ b/node/src/mcp/handlers_delegate.rs
@@ -100,7 +100,10 @@ pub(super) async fn tool_grant_capability(params: &Value, state: &NodeState) -> 
         // GrantCapability effect (~100 + 50 computrons by default; round up).
         fee: 10_000,
         memo: Some(format!("grant capability: {permissions}")),
-        valid_until: None,
+        // `None` skips the executor's expiration check entirely
+        // (`turn/src/executor/execute.rs:426`) — bound it instead
+        // (`api::default_valid_until`).
+        valid_until: crate::api::default_valid_until(),
         // Use a signed action so the cell's `delegate: Signature` permission
         // accepts it. (Hosted-cell grants require the cell owner's signature.)
         call_forest: build_signed_forest(
@@ -244,7 +247,10 @@ pub(super) async fn tool_revoke_capability(params: &Value, state: &NodeState) ->
         nonce,
         fee: 0,
         memo: Some(format!("revoke capability slot {cap_slot}")),
-        valid_until: None,
+        // `None` skips the executor's expiration check entirely
+        // (`turn/src/executor/execute.rs:426`) — bound it instead
+        // (`api::default_valid_until`).
+        valid_until: crate::api::default_valid_until(),
         call_forest: build_forest_with_effects(agent_cell_id, vec![effect]),
         depends_on: vec![],
         previous_receipt_hash,
@@ -406,7 +412,10 @@ pub(super) async fn tool_delegate(params: &Value, state: &NodeState) -> McpToolR
             "delegate capability slot {} to {}",
             capability, to_agent_hex
         )),
-        valid_until: None,
+        // `None` skips the executor's expiration check entirely
+        // (`turn/src/executor/execute.rs:426`) — bound it instead
+        // (`api::default_valid_until`).
+        valid_until: crate::api::default_valid_until(),
         call_forest: build_forest_with_effects(agent_cell_id, vec![effect]),
         depends_on: vec![],
         previous_receipt_hash,
@@ -757,7 +766,10 @@ pub(super) async fn tool_exercise_bearer_cap(params: &Value, state: &NodeState) 
         // Cover Action-base + per-effect cost for the parsed effects.
         fee: 10_000,
         memo: Some(format!("bearer cap exercise: {method}")),
-        valid_until: None,
+        // `None` skips the executor's expiration check entirely
+        // (`turn/src/executor/execute.rs:426`) — bound it instead
+        // (`api::default_valid_until`).
+        valid_until: crate::api::default_valid_until(),
         call_forest: forest,
         depends_on: vec![],
         previous_receipt_hash,
@@ -1222,7 +1234,10 @@ pub(super) async fn tool_exercise_handoff_cert(params: &Value, state: &NodeState
         nonce: turn_nonce,
         fee: 10_000,
         memo: Some("captp.handoff-cert-exercise (mcp)".to_string()),
-        valid_until: None,
+        // `None` skips the executor's expiration check entirely
+        // (`turn/src/executor/execute.rs:426`) — bound it instead
+        // (`api::default_valid_until`).
+        valid_until: crate::api::default_valid_until(),
         call_forest: forest,
         depends_on: vec![],
         previous_receipt_hash,

--- a/node/src/mcp/handlers_privacy.rs
+++ b/node/src/mcp/handlers_privacy.rs
@@ -271,7 +271,10 @@ pub(super) async fn tool_private_transfer(params: &Value, state: &NodeState) -> 
         nonce,
         fee: 0,
         memo: Some("private transfer".to_string()),
-        valid_until: None,
+        // `None` skips the executor's expiration check entirely
+        // (`turn/src/executor/execute.rs:426`) — bound it instead
+        // (`api::default_valid_until`).
+        valid_until: crate::api::default_valid_until(),
         call_forest: build_forest_with_effects(from_cell_id, effects),
         depends_on: vec![],
         previous_receipt_hash,

--- a/node/src/mcp/handlers_verify.rs
+++ b/node/src/mcp/handlers_verify.rs
@@ -747,7 +747,10 @@ pub(super) async fn tool_sign_sovereign_witness(
         call_forest: super::proof::build_forest_with_effects(cell_id, effects),
         fee: 0,
         memo: None,
-        valid_until: None,
+        // This is the exact turn the tool tells the caller to submit
+        // (`witnessed_turn_postcard_hex`, below) — `None` would skip the executor's
+        // expiration check entirely (`turn/src/executor/execute.rs:426`) on it.
+        valid_until: crate::api::default_valid_until(),
         previous_receipt_hash: None,
         depends_on: Vec::new(),
         conservation_proof: None,

--- a/node/src/mcp/mod.rs
+++ b/node/src/mcp/mod.rs
@@ -1951,4 +1951,45 @@ mod tests {
             "a non-covering/garbage _cap must be rejected"
         );
     }
+
+    /// Ratchet against the `valid_until: None` sentinel regrowing in an MCP handler.
+    ///
+    /// Every `Turn` these handlers build is executed by a real `TurnExecutor`
+    /// (`mcp_execute`, `mcp_execute_via_producer`), whose expiration check is
+    /// `if let Some(valid_until) = turn.valid_until { ... }` (`turn/src/executor/execute.rs`,
+    /// around line 426) — entirely SKIPPED on `None`. A turn built that way never expires,
+    /// no matter how stale. This was a real, repeated bug: found and fixed at three other
+    /// call sites (the thin-HTTP `/turn/submit` path, the SDK's `runtime::default_valid_until`
+    /// for issue #46, and `tool_submit_turn` itself, above in this same handler set) before
+    /// this pass swept the remaining ones.
+    ///
+    /// `default_valid_until()` (`api.rs`) exists precisely so every one of these sites can
+    /// share ONE horizon policy instead of re-deriving (or omitting) it. This test does not
+    /// re-assert that function's own contract — `api::tests::
+    /// default_valid_until_is_some_and_an_expired_stamp_is_still_rejected` already pins that
+    /// `Some` alone is not enough, an *expired* stamp must still be rejected — it pins the
+    /// narrower, source-level fact that regressed here: no handler literally spells out the
+    /// sentinel again. `include_str!` reads each file at COMPILE time, so this cannot go stale
+    /// against what actually ships; it fails the moment a `Turn { .. }` literal in any of these
+    /// files is written with `valid_until: None,` again, by any author, in any handler added
+    /// later to these same files.
+    #[test]
+    fn no_mcp_handler_rebuilds_the_unbounded_valid_until_sentinel() {
+        let files: &[(&str, &str)] = &[
+            ("handlers_act.rs", include_str!("handlers_act.rs")),
+            ("handlers_delegate.rs", include_str!("handlers_delegate.rs")),
+            ("handlers_apps.rs", include_str!("handlers_apps.rs")),
+            ("handlers_privacy.rs", include_str!("handlers_privacy.rs")),
+            ("handlers_verify.rs", include_str!("handlers_verify.rs")),
+        ];
+        for (name, src) in files {
+            assert!(
+                !src.contains("valid_until: None,"),
+                "{name} builds a Turn with `valid_until: None` — this turn will NEVER expire \
+                 (the executor's expiration check is skipped entirely on `None`, \
+                 turn/src/executor/execute.rs:426). Use `crate::api::default_valid_until()` \
+                 instead, as every other Turn literal in the mcp handlers now does."
+            );
+        }
+    }
 }


### PR DESCRIPTION
## What

Same defect as #80, at the 11 other call sites in `node/src/mcp/handlers_*.rs`
that build a real `Turn` and hand it to `TurnExecutor` (via `mcp_execute` /
`mcp_execute_via_producer`):

```rust
valid_until: None,
```

The executor's expiration check is:

```rust
if let Some(valid_until) = turn.valid_until {
    if self.current_timestamp > valid_until { /* reject */ }
}
```

(`turn/src/executor/execute.rs:426`) — entirely **skipped** on `None`. A turn
built that way never expires, no matter how stale.

This makes `api::default_valid_until()` `pub(crate)` (same change #80 makes;
identical diff on that one line, so the two PRs merge cleanly in either
order) and reuses it at every remaining site:

| File | Handlers fixed |
|---|---|
| `handlers_act.rs` | `tool_submit_turn` (= #80's fix, included here so this PR is self-contained and its own regression test passes standalone), `tool_captp_deliver`, `tool_bilateral_action` |
| `handlers_delegate.rs` | `tool_grant_capability`, `tool_revoke_capability`, `tool_delegate`, `tool_exercise_bearer_cap`, `tool_exercise_handoff_cert` |
| `handlers_apps.rs` | `tool_create_cell_from_factory_effect`, `run_starbridge_action` |
| `handlers_privacy.rs` | `tool_private_transfer` |
| `handlers_verify.rs` | `tool_sign_sovereign_witness` |

`tool_sign_sovereign_witness` is worth calling out on its own: it doesn't
execute the turn itself — it hands `witnessed_turn_postcard_hex` back to the
caller with an explicit `"Submit witnessed_turn_postcard_hex"` instruction.
`valid_until: None` there meant the turn the tool *tells callers to submit*
would never expire, not just an internal one.

## Ratchet

Added `mcp::tests::no_mcp_handler_rebuilds_the_unbounded_valid_until_sentinel`:
reads all five handler files at compile time via `include_str!` and fails if
`"valid_until: None,"` reappears in any of them — so a handler added later to
these files can't reintroduce this bug silently.

## Test

```
DREGG_TEST_ALLOW_MISSING_LEAN=1 DREGG_ALLOW_UNAUDITED_PQ=1 \
  cargo test -p dregg-node --lib mcp::
```
→ 49 passed; 0 failed (48 preexisting + the new ratchet test). No
regressions. 8 of the 11 sites are already exercised end-to-end by existing
commit-path tests in this same run (`bilateral_action_transfer_commits_...`,
`grant_capability_commits_...`, `exercise_bearer_cap_honest_delegation_commits`,
`exercise_handoff_cert_honest_path_commits`,
`register_name_commits_and_reports_a_live_attestation_disposition`, and
`mcp_submit_turn_commits_...`).

(`DREGG_TEST_ALLOW_MISSING_LEAN=1 DREGG_ALLOW_UNAUDITED_PQ=1` is a local
workaround for a machine without the linked verified Lean/PQ archive — noted
here for transparency, not a code change.)

## Scope note

`captp_deliver`, `private_transfer`, and `sign_sovereign_witness` have no
existing dedicated end-to-end test in this repo (checked via grep across
`node/tests/` and `node/src/mcp/`), so this PR doesn't have a pre-existing
regression harness to lean on for those three specifically — the fix there
is the same one-line, already-unit-tested `default_valid_until()` reuse as
everywhere else, plus the new source-level ratchet above.

Related: #80 (same fix, `tool_submit_turn` only), #78 (SDK, issue #46).
