### PR TITLE
intent: bound the unbounded valid_until on 2 fulfillment-payment Turn literals

### DIFF
--- a/intent/src/fulfillment.rs
+++ b/intent/src/fulfillment.rs
@@ -929,6 +929,29 @@ pub fn compute_intent_request_hash(intent: &Intent) -> BabyBear {
 /// Default grace period (in blocks) for the fulfillment payment conditional turn.
 const FULFILLMENT_PAYMENT_GRACE_BLOCKS: u64 = 100;
 
+/// Validity horizon (wall-clock seconds) stamped onto turns this module constructs.
+///
+/// `Turn::valid_until` (`turn/src/turn.rs`) is compared against the executor's
+/// `current_timestamp` — a wall-clock Unix timestamp, entirely separate from
+/// `block_height` (`turn/src/executor/mod.rs`). Do NOT stamp `current_height` (this
+/// module's block-height parameter) in here: as a "timestamp" it would already be far
+/// in the past and expire the turn on arrival. Leaving `valid_until` as `None` is worse
+/// than either: the executor's expiration check is `if let Some(valid_until) =
+/// turn.valid_until { .. }` (`turn/src/executor/execute.rs:426`) — entirely SKIPPED on
+/// `None`, so a turn built that way never expires, no matter how stale. Mirrors
+/// `default_valid_until` in `node/src/api.rs` / `sdk/src/runtime.rs` (same rationale,
+/// same fix, same 1-hour horizon); this crate has no dependency on either, hence its
+/// own copy.
+const FULFILLMENT_TURN_VALIDITY_HORIZON_SECS: i64 = 3600;
+
+fn default_valid_until() -> Option<i64> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    Some(now + FULFILLMENT_TURN_VALIDITY_HORIZON_SECS)
+}
+
 /// Create a ConditionalTurn that transfers payment from the intent creator to the
 /// fulfiller, conditioned on the fulfillment proof being valid.
 ///
@@ -1016,7 +1039,10 @@ pub fn create_fulfillment_turn(
             "fulfillment payment for intent {:02x}{:02x}...",
             intent.id[0], intent.id[1]
         )),
-        valid_until: None,
+        // `valid_until: None` skips the executor's expiration check entirely
+        // (`turn/src/executor/execute.rs:426`) — bound it with the module's shared
+        // wall-clock horizon instead of `current_height` (a block height, not a timestamp).
+        valid_until: default_valid_until(),
         previous_receipt_hash: None,
         depends_on: vec![],
         conservation_proof: None,
@@ -1668,7 +1694,10 @@ pub fn execute_committed_fulfillment_flow(
             "committed fulfillment payment for intent {:02x}{:02x}...",
             intent.id[0], intent.id[1]
         )),
-        valid_until: None,
+        // `valid_until: None` skips the executor's expiration check entirely
+        // (`turn/src/executor/execute.rs:426`) — bound it with the module's shared
+        // wall-clock horizon instead of `current_height` (a block height, not a timestamp).
+        valid_until: default_valid_until(),
         previous_receipt_hash: None,
         depends_on: vec![],
         conservation_proof: None,
@@ -3696,5 +3725,61 @@ mod tests {
             }
             other => panic!("expected PredicateProofFailed, got {:?}", other),
         }
+    }
+
+    /// The sentinel must be `Some` — `None` here skips the executor's expiration check
+    /// entirely (`turn/src/executor/execute.rs:426`), so a turn built that way never
+    /// expires no matter how stale.
+    #[test]
+    fn default_valid_until_is_some() {
+        assert!(
+            default_valid_until().is_some(),
+            "a None here means the fulfillment-payment turn never expires — see module docs \
+             on default_valid_until"
+        );
+    }
+
+    /// The stamped deadline must be a future WALL-CLOCK second count, not a block height —
+    /// this module also has a `current_height` parameter nearby and it would be an easy
+    /// mistake to stamp that instead (it would already be far in the past as a timestamp).
+    #[test]
+    fn default_valid_until_is_a_future_wall_clock_horizon_not_a_block_height() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let stamped =
+            default_valid_until().expect("must be Some, see default_valid_until_is_some");
+        assert!(
+            stamped > now,
+            "stamped valid_until ({stamped}) must be strictly after now ({now})"
+        );
+        assert!(
+            stamped <= now + FULFILLMENT_TURN_VALIDITY_HORIZON_SECS,
+            "stamped valid_until ({stamped}) must not exceed the declared horizon (now={now} + \
+             {FULFILLMENT_TURN_VALIDITY_HORIZON_SECS}s) — a block height here would be off by \
+             many orders of magnitude in the wrong direction"
+        );
+    }
+
+    /// Ratchet against the unbounded `valid_until` sentinel regrowing in a `Turn` literal
+    /// this file builds. `include_str!` reads this file at COMPILE time, so this cannot go
+    /// stale against what actually ships. This file is itself the one scanned, which is why
+    /// the needle is assembled at runtime rather than written as one literal — a literal
+    /// copy of it here would trivially match itself.
+    #[test]
+    fn no_fulfillment_turn_rebuilds_the_unbounded_valid_until_sentinel() {
+        let src = include_str!("fulfillment.rs");
+        let sentinel_field = "valid_until";
+        let sentinel_value = "None";
+        let needle = format!("{sentinel_field}: {sentinel_value},");
+        assert!(
+            !src.contains(&needle),
+            "fulfillment.rs builds a Turn with `{sentinel_field}` bound to a bare \
+             `{sentinel_value}` — this turn will NEVER expire (the executor's expiration \
+             check is skipped entirely when this field is `{sentinel_value}`, \
+             turn/src/executor/execute.rs:426). Use `default_valid_until()` instead, as \
+             every other Turn literal in this file now does."
+        );
     }
 }


### PR DESCRIPTION
## What

`create_fulfillment_turn` and `execute_committed_fulfillment_flow` (`intent/src/fulfillment.rs`) both build a `Turn` with `valid_until: None`. The executor's expiration check is `if let Some(valid_until) = turn.valid_until { .. }` (`turn/src/executor/execute.rs:426`) — entirely skipped on `None`, so a turn built this way never expires, no matter how stale.

Same bug pattern already fixed elsewhere in this repo: #78 (SDK), #80/#81 (node/src/mcp handlers).

## Reachability, stated honestly

Neither site is reached from the live node's current HTTP surface — `node/src/api.rs`'s `commit_intent_fulfillment_verified` calls the "verified" flow, which settles balances directly via `verified_settle` and never hands its `Turn` to a `TurnExecutor`. But:

- Both functions are `pub fn` in a crate with real downstream consumers (`dreggnet-market`, `bridge`, `discord-bot`, `wasm`, `sdk`).
- `create_fulfillment_turn`'s own legacy caller, `execute_fulfillment_flow_with_key`, **does** call `executor.execute()` on this exact turn.

Per this repo's `CLAUDE.md` doctrine, a defect in code that reaches a real executor isn't deferred because today's entry point happens to route around it.

## Fix

- Added a local `default_valid_until()`. `dregg-intent` depends on neither `dregg-node` nor `dregg-sdk`, so there's no existing helper to import — this is its own copy, same 1-hour wall-clock horizon as the other three.
- **Explicitly does not stamp `current_height`** (this module's existing block-height parameter, sitting right next to both fixes). `valid_until` is compared against the executor's wall-clock `current_timestamp`, a field entirely separate from `block_height` (`turn/src/executor/mod.rs`). Stamping a block height there would expire the turn immediately on arrival, not fix anything — documented directly in the new function's doc comment so it isn't a mistake the next reader makes.

## Ratchet

`no_fulfillment_turn_rebuilds_the_unbounded_valid_until_sentinel` scans this file at compile time (`include_str!`) for the literal `valid_until: None,` sentinel reappearing. Also added the same `default_valid_until_is_some` / `is_a_future_wall_clock_horizon` pair used in `node/src/api.rs` and `sdk/src/runtime.rs` to pin this function's own contract.

## Test

```
DREGG_TEST_ALLOW_MISSING_LEAN=1 DREGG_ALLOW_UNAUDITED_PQ=1 cargo test -p dregg-intent --lib -- fulfillment::
```
→ 49 passed, 0 failed (46 preexisting + 3 new).

(`DREGG_TEST_ALLOW_MISSING_LEAN` / `DREGG_ALLOW_UNAUDITED_PQ` are local-environment env vars for a checkout missing the verified Lean/PQ archive — not a code change.)

## Related

#78, #80, #81 — same bug pattern, other crates.
