### PR TITLE
coord: bind the atomic 2PC turn's valid_until to a deadline decided once

### DIFF
--- a/coord/src/atomic.rs
+++ b/coord/src/atomic.rs
@@ -16,6 +16,38 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::CoordError;
 
+/// Validity horizon (wall-clock seconds) for atomic-turn proposals built with this
+/// default.
+///
+/// `Turn::valid_until` (`turn/src/turn.rs`) is compared against the executor's
+/// wall-clock `current_timestamp`, entirely separate from `block_height`
+/// (`turn/src/executor/mod.rs`). `None` skips the executor's expiration check
+/// entirely (`turn/src/executor/execute.rs:426`) — a turn built that way never
+/// expires, no matter how stale. Mirrors `default_valid_until` in `node/src/api.rs` /
+/// `sdk/src/runtime.rs` / `intent/src/fulfillment.rs` (same rationale, same fix, same
+/// 1-hour horizon); `dregg-coord` depends on none of those crates, hence its own copy.
+///
+/// `pub`, not `pub(crate)`: the one production call site that proposes an atomic
+/// forest lives in `dregg-node` (`node/src/api.rs`), a different crate.
+const ATOMIC_TURN_VALIDITY_HORIZON_SECS: i64 = 3600;
+
+/// Wall-clock Unix seconds, `now`.
+///
+/// Shared by [`default_valid_until`] (stamps the deadline) and `commit`/`apply_commit`
+/// (stamp the executor's clock the deadline is checked against — see the note on
+/// `TurnExecutor::current_timestamp` at both call sites: without it, `valid_until`
+/// alone is inert here).
+fn wall_clock_now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+pub fn default_valid_until() -> Option<i64> {
+    Some(wall_clock_now_secs() + ATOMIC_TURN_VALIDITY_HORIZON_SECS)
+}
+
 // ─── AtomicForest ──────────────────────────────────────────────────────────────
 
 /// A multi-party call forest: actions contributed by multiple participants
@@ -32,27 +64,54 @@ pub struct AtomicForest {
     pub initiator: CellId,
     /// The fee for this atomic turn.
     pub fee: u64,
+    /// Wall-clock deadline (Unix seconds) for the `Turn` this forest will become.
+    ///
+    /// Decided ONCE, here, at propose time — NOT re-derived independently by
+    /// `Coordinator::commit()` and `Participant::apply_commit()`, which build the same
+    /// logical `Turn` at different times, on different machines. If each stamped its
+    /// own `now + horizon` independently, a participant applying a commit long after
+    /// the coordinator built it would launder a stale proposal into artificial
+    /// freshness — the exact bug this field exists to close, reopened by a different
+    /// door. Included in `hash` (below), so every participant sees and implicitly
+    /// signs off on the deadline before voting Yes.
+    pub valid_until: Option<i64>,
     /// BLAKE3 hash of the entire atomic forest structure.
     pub hash: [u8; 32],
 }
 
 impl AtomicForest {
     /// Create a new atomic forest, computing its hash.
+    ///
+    /// `valid_until` is REQUIRED (not defaulted to `None` here) so every call site
+    /// makes an explicit choice. Production callers should use
+    /// [`default_valid_until`]; test fixtures that don't exercise expiration are free
+    /// to pass `None` — see `no_atomic_forest_field_omits_the_unbounded_sentinel_by_typo`
+    /// in this module's tests for why that is a different, unenforceable-by-type
+    /// property from `Turn::valid_until: None` being reachable in `commit`/`apply_commit`.
     pub fn new(
         participants: Vec<[u8; 32]>,
         forest: CallForest,
         preconditions: Vec<(CellId, Preconditions)>,
         initiator: CellId,
         fee: u64,
+        valid_until: Option<i64>,
     ) -> Self {
         let forest_hash = forest.compute_hash();
-        let hash = Self::compute_hash(&participants, &forest_hash, &preconditions, &initiator, fee);
+        let hash = Self::compute_hash(
+            &participants,
+            &forest_hash,
+            &preconditions,
+            &initiator,
+            fee,
+            valid_until,
+        );
         AtomicForest {
             participants,
             forest,
             preconditions,
             initiator,
             fee,
+            valid_until,
             hash,
         }
     }
@@ -69,6 +128,7 @@ impl AtomicForest {
         preconditions: &[(CellId, Preconditions)],
         initiator: &CellId,
         fee: u64,
+        valid_until: Option<i64>,
     ) -> [u8; 32] {
         let mut hasher = blake3::Hasher::new();
         hasher.update(b"dregg-coord:atomic-forest");
@@ -83,6 +143,16 @@ impl AtomicForest {
         }
         hasher.update(initiator.as_bytes());
         hasher.update(&fee.to_le_bytes());
+        // Tagged explicitly (a leading 0/1 byte) so None and Some(0) hash differently.
+        match valid_until {
+            Some(v) => {
+                hasher.update(&[1u8]);
+                hasher.update(&v.to_le_bytes());
+            }
+            None => {
+                hasher.update(&[0u8]);
+            }
+        };
         *hasher.finalize().as_bytes()
     }
 
@@ -682,7 +752,12 @@ impl Coordinator {
             call_forest: forest.forest.clone(),
             fee: forest.fee,
             memo: Some("atomic multi-party turn".to_string()),
-            valid_until: None,
+            // Read from the forest, NOT re-derived here: commit() and apply_commit()
+            // build the same logical Turn at different times/places (coordinator now,
+            // each participant potentially much later). Independently stamping
+            // `now + horizon` at each site would let a participant launder a stale
+            // proposal into artificial freshness. See AtomicForest::valid_until's doc.
+            valid_until: forest.valid_until,
             depends_on: Vec::new(),
             previous_receipt_hash: None,
             conservation_proof: None,
@@ -697,7 +772,15 @@ impl Coordinator {
         };
 
         // Execute the turn with proper metering.
-        let executor = TurnExecutor::new(self.costs.clone());
+        let mut executor = TurnExecutor::new(self.costs.clone());
+        // `TurnExecutor::new` defaults `current_timestamp` to 0 — without advancing it,
+        // the expiration check (`turn/src/executor/execute.rs:426`,
+        // `if self.current_timestamp > valid_until`) can never fire no matter what
+        // `turn.valid_until` says, making the fix above inert. This executor is
+        // constructed fresh per call and isn't wired through the node's
+        // `executor_setup::configure_turn_executor` (unlike the thin-HTTP path), so
+        // nothing else sets this; do it here.
+        executor.current_timestamp = wall_clock_now_secs();
         let result = executor.execute(&turn, ledger);
 
         match result {
@@ -1205,7 +1288,12 @@ impl Participant {
             call_forest: forest.forest.clone(),
             fee: forest.fee,
             memo: Some("atomic multi-party turn".to_string()),
-            valid_until: None,
+            // Read from the forest, NOT re-derived here: commit() and apply_commit()
+            // build the same logical Turn at different times/places (coordinator now,
+            // each participant potentially much later). Independently stamping
+            // `now + horizon` at each site would let a participant launder a stale
+            // proposal into artificial freshness. See AtomicForest::valid_until's doc.
+            valid_until: forest.valid_until,
             depends_on: Vec::new(),
             previous_receipt_hash: None,
             conservation_proof: None,
@@ -1219,7 +1307,11 @@ impl Participant {
             effect_witness_index_map: Vec::new(),
         };
 
-        let executor = TurnExecutor::new(self.costs.clone());
+        let mut executor = TurnExecutor::new(self.costs.clone());
+        // See the identical comment in Coordinator::commit(): without advancing
+        // current_timestamp past its TurnExecutor::new default of 0, valid_until can
+        // never be exceeded and the expiration check is inert.
+        executor.current_timestamp = wall_clock_now_secs();
         let result = executor.execute(&turn, &mut self.ledger);
 
         // Clear active proposal state on successful apply.
@@ -1267,10 +1359,16 @@ pub struct AtomicForestBuilder {
     preconditions: Vec<(CellId, Preconditions)>,
     initiator: Option<CellId>,
     fee: u64,
+    valid_until: Option<i64>,
 }
 
 impl AtomicForestBuilder {
     /// Create a new builder.
+    ///
+    /// `valid_until` defaults to [`default_valid_until()`], NOT `None` — a builder
+    /// whose caller forgets to set it should still produce an expiring turn. Call
+    /// [`Self::set_valid_until`] to override (e.g. a test that wants `None`, or a
+    /// caller with its own horizon policy).
     pub fn new() -> Self {
         AtomicForestBuilder {
             participants: Vec::new(),
@@ -1278,6 +1376,7 @@ impl AtomicForestBuilder {
             preconditions: Vec::new(),
             initiator: None,
             fee: 0,
+            valid_until: default_valid_until(),
         }
     }
 
@@ -1311,6 +1410,13 @@ impl AtomicForestBuilder {
         self
     }
 
+    /// Override the validity deadline (defaults to [`default_valid_until()`] — see
+    /// [`Self::new`]).
+    pub fn set_valid_until(&mut self, valid_until: Option<i64>) -> &mut Self {
+        self.valid_until = valid_until;
+        self
+    }
+
     /// Build the atomic forest.
     pub fn build(self) -> Result<AtomicForest, CoordError> {
         let initiator = self.initiator.ok_or(CoordError::NoParticipants)?;
@@ -1320,6 +1426,7 @@ impl AtomicForestBuilder {
             self.preconditions,
             initiator,
             self.fee,
+            self.valid_until,
         );
         forest.validate()?;
         Ok(forest)

--- a/coord/src/coord_diff.rs
+++ b/coord/src/coord_diff.rs
@@ -400,6 +400,7 @@ mod two_phase_commit_diff {
             preconditions,
             id0,
             0,
+            None,
         );
 
         let nodes = vec![node_id(1), node_id(2), node_id(3)];

--- a/coord/src/entangled_diff.rs
+++ b/coord/src/entangled_diff.rs
@@ -241,6 +241,7 @@ mod atomicity_diff {
             preconditions,
             id0,
             0,
+            None,
         );
 
         let nodes = vec![node_id(1), node_id(2), node_id(3)];

--- a/coord/src/lib.rs
+++ b/coord/src/lib.rs
@@ -115,7 +115,7 @@ mod coord_diff;
 pub use atomic::{
     AbortMessage, AssetId, AtomicForest, ChainBreak, CommitMessage, Coordinator, CoordinatorState,
     Decision, JointId, MixedAdmitError, MixedJoint, Participant, PrivateContribution, PrivateLeg,
-    PrivateLegProof, ProposeMessage, StateCommit, Vote, check_chain_bound,
+    PrivateLegProof, ProposeMessage, StateCommit, Vote, check_chain_bound, default_valid_until,
 };
 pub use budget::{
     BudgetError, BudgetSlice, FastUnlockManager, StingrayCounter, UnlockCertificate, UnlockRequest,

--- a/coord/src/private_leg.rs
+++ b/coord/src/private_leg.rs
@@ -97,7 +97,7 @@ fn public_backbone() -> (Ledger, AtomicForest) {
     let mut forest = CallForest::new();
     forest.add_root(transfer_action(id0, id1, 10));
 
-    let af = AtomicForest::new(vec![node_id(1)], forest, vec![], id0, 0);
+    let af = AtomicForest::new(vec![node_id(1)], forest, vec![], id0, 0, None);
     (ledger, af)
 }
 

--- a/coord/src/tests.rs
+++ b/coord/src/tests.rs
@@ -447,6 +447,7 @@ mod atomic_forest_tests {
             )],
             cell_a.id(),
             0,
+            None,
         );
 
         assert!(af.validate().is_ok());
@@ -464,6 +465,7 @@ mod atomic_forest_tests {
             vec![],
             CellId::from_bytes([0u8; 32]),
             0,
+            None,
         );
         assert_eq!(af.validate().unwrap_err(), CoordError::EmptyForest);
     }
@@ -485,7 +487,7 @@ mod atomic_forest_tests {
             witness_blobs: vec![],
         });
 
-        let af = AtomicForest::new(vec![], forest, vec![], cell_a.id(), 0);
+        let af = AtomicForest::new(vec![], forest, vec![], cell_a.id(), 0, None);
         assert_eq!(af.validate().unwrap_err(), CoordError::NoParticipants);
     }
 
@@ -587,6 +589,7 @@ mod coordinator_tests {
             ],
             id_a,
             0,
+            None,
         );
 
         let nodes = vec![node_id(1), node_id(2)];
@@ -1024,6 +1027,59 @@ mod coordinator_tests {
         let err = coord.propose(af).unwrap_err();
         assert!(matches!(err, CoordError::BudgetExceeded { .. }));
     }
+
+    /// This is the property the whole `AtomicForest::valid_until` field exists for:
+    /// a stale proposal must be REFUSED at commit, not silently accepted.
+    ///
+    /// Non-vacuity matters more here than in most tests: before this fix, this exact
+    /// scenario committed successfully — twice over. `Turn { valid_until: None, .. }`
+    /// skipped the executor's expiration check entirely
+    /// (`turn/src/executor/execute.rs:426`), AND even with a real `Some(past)` deadline,
+    /// `TurnExecutor::new`'s default `current_timestamp: 0` meant `0 > valid_until` was
+    /// false for any realistic (positive, post-1970) deadline — the check could never
+    /// fire either way. Both gaps are closed by this commit; this test would have
+    /// FAILED (committed instead of rejecting) against the pre-fix code on either count.
+    #[test]
+    fn commit_refuses_a_forest_whose_deadline_has_already_passed() {
+        let _native = crate::atomic::NativeDifferentialArmed::new();
+        let (mut ledger, _id_a, _id_b, stale_af, signing_keys, participant_keys) =
+            setup_two_party();
+        // Rebuild the SAME forest with a deadline far in the past (1970 + 1 day).
+        let stale_af = AtomicForest::new(
+            stale_af.participants,
+            stale_af.forest,
+            stale_af.preconditions,
+            stale_af.initiator,
+            stale_af.fee,
+            Some(86_400),
+        );
+        let mut coord = Coordinator::new(
+            node_id(1),
+            coord_signing_key(),
+            2,
+            zero_costs(),
+            TEST_MAX_BUDGET,
+            participant_keys,
+        );
+
+        let prop_msg = coord.propose(stale_af.clone()).unwrap();
+        let sig_a = Vote::sign_yes(&prop_msg.proposal_id, &stale_af.hash, &signing_keys[0]);
+        coord.receive_vote(node_id(1), Vote::yes(sig_a)).unwrap();
+        let sig_b = Vote::sign_yes(&prop_msg.proposal_id, &stale_af.hash, &signing_keys[1]);
+        let decision = coord.receive_vote(node_id(2), Vote::yes(sig_b)).unwrap();
+        assert_eq!(decision, Some(Decision::Commit), "quorum reached, as normal");
+
+        let err = coord
+            .commit(&mut ledger)
+            .expect_err("a Turn whose valid_until is in 1970 must be refused, not committed");
+        assert!(
+            matches!(
+                err,
+                CoordError::TurnExecution(dregg_turn::TurnError::Expired { .. })
+            ),
+            "expected TurnError::Expired, got: {err:?}"
+        );
+    }
 }
 
 mod participant_tests {
@@ -1081,6 +1137,7 @@ mod participant_tests {
             ],
             id_a,
             0,
+            None,
         );
 
         let nodes = vec![node_id(1), node_id(2)];
@@ -1172,6 +1229,73 @@ mod participant_tests {
         // Verify local state updated.
         assert_eq!(participant.ledger.get(&id_a).unwrap().state.balance(), 9500);
         assert_eq!(participant.ledger.get(&id_b).unwrap().state.balance(), 5500);
+    }
+
+    /// The participant-side twin of
+    /// `coordinator_tests::commit_refuses_a_forest_whose_deadline_has_already_passed`:
+    /// `apply_commit` must refuse a forest whose `valid_until` has already passed too,
+    /// not just `commit`. This is the scenario the whole design exists for — a
+    /// participant applying a QC-certified commit long after the coordinator built it —
+    /// so it is deliberately NOT the same forest object as the coordinator's test, only
+    /// the same shape: this participant only ever sees what arrives over the wire.
+    #[test]
+    fn apply_commit_refuses_a_forest_whose_deadline_has_already_passed() {
+        let (ledger, id_a, id_b, af, signing_keys, participant_keys) =
+            setup_participant_scenario();
+        let stale_af = AtomicForest::new(
+            af.participants,
+            af.forest,
+            af.preconditions,
+            af.initiator,
+            af.fee,
+            Some(86_400), // 1970 + 1 day — long expired by wall-clock "now".
+        );
+        let mut participant =
+            Participant::with_costs(id_a, node_id(1), signing_keys[0], ledger, zero_costs());
+
+        let proposal_id = stale_af.hash;
+        let sig_1 = Vote::sign_yes(&proposal_id, &stale_af.hash, &signing_keys[0]);
+        let sig_2 = Vote::sign_yes(&proposal_id, &stale_af.hash, &signing_keys[1]);
+        let commit = CommitMessage {
+            proposal_id,
+            receipt: dregg_turn::TurnReceipt {
+                turn_hash: [0u8; 32],
+                forest_hash: [0u8; 32],
+                pre_state_hash: [0u8; 32],
+                post_state_hash: [0u8; 32],
+                timestamp: 0,
+                effects_hash: [0u8; 32],
+                computrons_used: 0,
+                action_count: 1,
+                previous_receipt_hash: None,
+                agent: id_a,
+                federation_id: [0u8; 32],
+                routing_directives: vec![],
+                introduction_exports: vec![],
+                derivation_records: vec![],
+                emitted_events: vec![],
+                executor_signature: None,
+                finality: Default::default(),
+                was_encrypted: false,
+                was_burn: false,
+                consumed_capabilities: vec![],
+            },
+            signatures: vec![(node_id(1), sig_1), (node_id(2), sig_2)],
+        };
+
+        let err = participant
+            .apply_commit(&commit, &stale_af, &participant_keys, 2)
+            .expect_err("a Turn whose valid_until is in 1970 must be refused, not applied");
+        assert!(
+            matches!(
+                err,
+                CoordError::TurnExecution(dregg_turn::TurnError::Expired { .. })
+            ),
+            "expected TurnError::Expired, got: {err:?}"
+        );
+        // And the ledger must be UNTOUCHED — a refused apply must not partially move state.
+        assert_eq!(participant.ledger.get(&id_a).unwrap().state.balance(), 10000);
+        assert_eq!(participant.ledger.get(&id_b).unwrap().state.balance(), 5000);
     }
 
     #[test]
@@ -1306,6 +1430,7 @@ mod integration {
             ],
             id_a,
             0,
+            None,
         );
 
         let mut coord = Coordinator::new(
@@ -1399,6 +1524,7 @@ mod integration {
             ],
             id_a,
             0,
+            None,
         );
 
         // Threshold 2 of 3 (majority).
@@ -1463,7 +1589,7 @@ mod integration {
             witness_blobs: vec![],
         });
 
-        let af = AtomicForest::new(vec![node_a, node_b, node_c], forest, vec![], id_a, 0);
+        let af = AtomicForest::new(vec![node_a, node_b, node_c], forest, vec![], id_a, 0, None);
 
         // Need all 3.
         let mut coord = Coordinator::new(
@@ -1487,5 +1613,128 @@ mod integration {
             )
             .unwrap();
         assert_eq!(decision, Some(Decision::Abort));
+    }
+}
+
+mod valid_until_tests {
+    use super::*;
+    use crate::atomic::default_valid_until;
+
+    /// The sentinel must be `Some` — `None` here skips the executor's expiration check
+    /// entirely (`turn/src/executor/execute.rs:426`), so a `Turn` built from a forest
+    /// that used this default would never expire, no matter how stale.
+    #[test]
+    fn default_valid_until_is_some() {
+        assert!(
+            default_valid_until().is_some(),
+            "a None here means every atomic turn using this default never expires — see \
+             the doc comment on default_valid_until"
+        );
+    }
+
+    /// The stamped deadline must be a future wall-clock second count.
+    #[test]
+    fn default_valid_until_is_a_future_wall_clock_horizon() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let stamped =
+            default_valid_until().expect("must be Some, see default_valid_until_is_some");
+        assert!(
+            stamped > now,
+            "stamped valid_until ({stamped}) must be strictly after now ({now})"
+        );
+    }
+
+    /// `AtomicForestBuilder::new()` must default to an expiring deadline, not `None` — a
+    /// caller who forgets to call `set_valid_until` should still get a safe forest.
+    #[test]
+    fn builder_defaults_to_an_expiring_deadline_not_none() {
+        let cell_a = make_cell(1, 10000);
+        let mut forest = CallForest::new();
+        forest.add_root(Action {
+            target: cell_a.id(),
+            method: [0u8; 32],
+            args: vec![],
+            authorization: Authorization::Unchecked,
+            preconditions: Preconditions::default(),
+            effects: vec![Effect::IncrementNonce { cell: cell_a.id() }],
+            may_delegate: DelegationMode::None,
+            commitment_mode: CommitmentMode::Full,
+            balance_change: None,
+            witness_blobs: vec![],
+        });
+        let mut builder = AtomicForestBuilder::new();
+        builder
+            .add_participant(node_id(1))
+            .set_forest(forest)
+            .set_initiator(cell_a.id());
+        // Deliberately never calls set_valid_until().
+        let af = builder.build().unwrap();
+        assert!(
+            af.valid_until.is_some(),
+            "a builder whose caller never calls set_valid_until() must still default to \
+             Some(..), not None"
+        );
+    }
+
+    /// `AtomicForest`'s hash MUST change when `valid_until` changes — it travels inside
+    /// the same hashed/signed envelope every Yes vote is bound to (see the field's doc
+    /// comment on why: the deadline must be decided ONCE and be tamper-evident, not
+    /// re-derivable independently by whoever later turns the forest into a `Turn`).
+    #[test]
+    fn hash_changes_when_valid_until_changes() {
+        let mut forest = CallForest::new();
+        forest.add_root(Action {
+            target: CellId::from_bytes([1u8; 32]),
+            method: [0u8; 32],
+            args: vec![],
+            authorization: Authorization::Unchecked,
+            preconditions: Preconditions::default(),
+            effects: vec![],
+            may_delegate: DelegationMode::None,
+            commitment_mode: CommitmentMode::Full,
+            balance_change: None,
+            witness_blobs: vec![],
+        });
+        let participants = vec![node_id(1)];
+        let initiator = CellId::from_bytes([1u8; 32]);
+
+        let af_none = AtomicForest::new(
+            participants.clone(),
+            forest.clone(),
+            vec![],
+            initiator,
+            0,
+            None,
+        );
+        let af_some = AtomicForest::new(participants, forest, vec![], initiator, 0, Some(12345));
+
+        assert_ne!(
+            af_none.hash, af_some.hash,
+            "changing valid_until must change the forest hash, or a participant's Yes vote \
+             would not actually bind them to the deadline they were shown"
+        );
+    }
+
+    /// Ratchet against the unbounded `valid_until` sentinel regrowing in the two places
+    /// this module builds a `Turn` from an `AtomicForest`: `Coordinator::commit` and
+    /// `Participant::apply_commit`. `include_str!` reads `atomic.rs` at COMPILE time, so
+    /// this cannot go stale against what actually ships.
+    #[test]
+    fn no_atomic_turn_rebuilds_the_unbounded_valid_until_sentinel() {
+        let src = include_str!("atomic.rs");
+        let sentinel_field = "valid_until";
+        let sentinel_value = "None";
+        let needle = format!("{sentinel_field}: {sentinel_value},");
+        assert!(
+            !src.contains(&needle),
+            "atomic.rs builds a Turn with `{sentinel_field}` bound to a bare \
+             `{sentinel_value}` — this turn will NEVER expire (the executor's expiration \
+             check is skipped entirely when this field is `{sentinel_value}`, \
+             turn/src/executor/execute.rs:426). Read it from the AtomicForest instead, as \
+             both commit() and apply_commit() now do."
+        );
     }
 }

--- a/coord/tests/twin_fail_closed.rs
+++ b/coord/tests/twin_fail_closed.rs
@@ -62,7 +62,7 @@ fn twoc_pc_fails_closed_without_gate() {
         balance_change: None,
         witness_blobs: vec![],
     });
-    let af = AtomicForest::new(nodes.clone(), forest, vec![], initiator, 0);
+    let af = AtomicForest::new(nodes.clone(), forest, vec![], initiator, 0, None);
 
     let mut coord = Coordinator::new(
         node_id(1),

--- a/exec-lean/tests/coord_gate_positive_polarity.rs
+++ b/exec-lean/tests/coord_gate_positive_polarity.rs
@@ -82,7 +82,7 @@ fn twoc_pc_commits_through_the_verified_gate_when_present() {
         balance_change: None,
         witness_blobs: vec![],
     });
-    let af = AtomicForest::new(nodes.clone(), forest, vec![], initiator, 0);
+    let af = AtomicForest::new(nodes.clone(), forest, vec![], initiator, 0, None);
 
     let mut coord = Coordinator::new(
         node_id(1),

--- a/node/src/api.rs
+++ b/node/src/api.rs
@@ -8343,6 +8343,11 @@ async fn post_atomic_proposal(
         vec![], // preconditions left empty; participants validate locally
         initiator,
         req.fee,
+        // Decided ONCE here, at propose time, and carried (hashed, signed) inside the
+        // forest — NOT re-derived independently wherever the forest is later turned
+        // into a Turn (coordinator commit, each participant's apply_commit). See
+        // AtomicForest::valid_until's doc.
+        dregg_coord::default_valid_until(),
     );
 
     // Create the coordinator with the node's identity.
@@ -12630,7 +12635,7 @@ mod tests {
             witness_blobs: vec![],
         };
         forest.add_root(action);
-        AtomicForest::new(participants, forest, vec![], cell_id, 0)
+        AtomicForest::new(participants, forest, vec![], cell_id, 0, None)
     }
 
     fn test_event(height: u64) -> CommittedEvent {

--- a/node/src/blocklace_sync.rs
+++ b/node/src/blocklace_sync.rs
@@ -18477,6 +18477,7 @@ mod tests {
             vec![], // no explicit preconditions: the participant validates locally
             from,
             0,
+            None,
         )
     }
 
@@ -18679,8 +18680,14 @@ mod tests {
         };
         let mut call_forest = dregg_turn::CallForest::new();
         call_forest.add_root(transfer);
-        let forest =
-            dregg_coord::AtomicForest::new(vec![node_a, node_b], call_forest, vec![], cell_a, 0);
+        let forest = dregg_coord::AtomicForest::new(
+            vec![node_a, node_b],
+            call_forest,
+            vec![],
+            cell_a,
+            0,
+            None,
+        );
         let forest_hash = forest.hash;
         let mut participant_keys = HashMap::new();
         participant_keys.insert(node_a, node_a);


### PR DESCRIPTION
## What

`Coordinator::commit()` and `Participant::apply_commit()` (`coord/src/atomic.rs`) each build the same logical `Turn` independently — the coordinator when the quorum is reached, each participant later when it receives the QC-certified `CommitMessage`, possibly on a different machine, possibly much later. Both built theirs with `valid_until: None`, which skips the executor's expiration check entirely (`turn/src/executor/execute.rs:426`) — the same bug pattern already fixed in #78, #80, #81, #82, #83.

## Why this site needed a different fix, not the same one-liner

Stamping `now + horizon` independently at `commit()` and at `apply_commit()` would let a participant applying a stale commit long after the coordinator built it launder that staleness into artificial freshness — reopening the exact bug through a different door.

**Fix:** the deadline is now decided ONCE, at propose time, and travels inside `AtomicForest` itself:

- Added `AtomicForest.valid_until: Option<i64>`, included in `compute_hash()` (tagged 0/1 so `None` and `Some(0)` don't collide) — every participant sees and implicitly signs off on the deadline before voting Yes. This breaks the forest's wire hash; per this repo's `CLAUDE.md` doctrine that's not a cost worth avoiding on a still-open protocol.
- `AtomicForest::new()` takes it as a **required** parameter (not defaulted to `None`), so every call site makes an explicit choice. The one production caller (`node/src/api.rs`'s atomic-propose handler) uses the new `coord::default_valid_until()`. The ~17 other call sites are all `#![cfg(test)]` fixtures.
- `AtomicForestBuilder` defaults `valid_until` to `default_valid_until()`, not `None` — a caller who forgets to call `set_valid_until()` still gets an expiring forest.
- `commit()` / `apply_commit()` now read `turn.valid_until` from `forest.valid_until` instead of hardcoding `None`.

## A second, deeper bug found while verifying the first one actually does anything

Both `commit()` and `apply_commit()` construct a bare `TurnExecutor::new(self.costs.clone())` per call, which defaults `current_timestamp` to `0` — so the expiration check's `self.current_timestamp > valid_until` was **false for any realistic positive deadline**, regardless of what `valid_until` said. The `valid_until` fix alone would have been cosmetic: hash-level correct, behaviorally inert.

Neither function is wired through the node's `executor_setup::configure_turn_executor` (what advances the real production `/turn/submit` path's clock) — this ad-hoc 2PC executor gets none of that. Fixed by stamping `current_timestamp` to wall-clock now right after construction, at both sites.

## Lean

Checked whether a formal Lean spec mirrors `AtomicForest`'s shape: `metatheory/Dregg2/Distributed/EntangledJoint.lean` describes it in prose comments only (`{ participants, forest, preconditions, initiator, hash }`), and that description already omits `fee` — a non-exhaustive summary, not a mirrored structure, already inaccurate before this change. Left it alone rather than partially fixing an already-partial description.

## Test

```
DREGG_TEST_ALLOW_MISSING_LEAN=1 DREGG_ALLOW_UNAUDITED_PQ=1 cargo test -p dregg-coord --lib -- valid_until_tests:: coordinator_tests:: participant_tests:: entangled_diff:: coord_diff::atomicity_diff integration::
```
→ 33 passed, 0 failed.

```
cargo test -p dregg-exec-lean --test coord_gate_positive_polarity
```
→ 2 passed, 0 failed (exercises the real 2PC commit path end to end).

```
cargo test -p dregg-coord --test twin_fail_closed
cargo test -p dregg-node --lib -- atomic
```
→ pre-existing PQ/ML-DSA-archive failures, confirmed byte-identical on this branch's base via `git stash` — unrelated to this change.

**Non-vacuity, checked directly:** temporarily reverted just the `current_timestamp` line in `commit()` and re-ran `commit_refuses_a_forest_whose_deadline_has_already_passed` — it **failed** (committed a Turn dated 1970 instead of rejecting it), proving the new test and the fix it's pinned to are both real. Restored before committing.

## Related

#78, #80, #81, #82, #83 — same bug pattern, other crates.
